### PR TITLE
Replaced use of "./bn ..." with equivalent "./gradlew ..."

### DIFF
--- a/2/2.1.md
+++ b/2/2.1.md
@@ -15,7 +15,7 @@ following commands to build GoCD
 
 ```bash
 ~/projects/go$ unset GEM_HOME GEM_PATH
-~/projects/go$ ./bn clean cruise:prepare dist
+~/projects/go$ ./gradlew clean agentGenericZip serverGenericZip
 ```
 
 After a successful build, the build artifacts are generated inside a directory
@@ -41,7 +41,7 @@ Prior to build via the IDE, we would have to prepare the working directory by co
 configured location. You can achive this by runnning the below command in the working directory:
 
 ```bash
-~/projects/go$ ./bn clean cruise:prepare
+~/projects/go$ ./gradlew clean fatJar
 ```
 
 After the preparation phase has succeeded, 

--- a/2/2.1.md
+++ b/2/2.1.md
@@ -41,7 +41,7 @@ Prior to build via the IDE, we would have to prepare the working directory by co
 configured location. You can achive this by runnning the below command in the working directory:
 
 ```bash
-~/projects/go$ ./gradlew clean fatJar
+~/projects/go$ ./gradlew clean prepare fatJar -PfastBuild
 ```
 
 After the preparation phase has succeeded, 

--- a/2/2.1.md
+++ b/2/2.1.md
@@ -18,19 +18,18 @@ following commands to build GoCD
 ~/projects/go$ ./gradlew clean agentGenericZip serverGenericZip
 ```
 
-After a successful build, the build artifacts are generated inside a directory
-named "**target**" in the working directory. The output directory contains JARs
-along with the packaged ZIP installer for GoCD Server and GoCD Agent.
-
+After a successful build, the build artifacts are generated inside **target/**
+sub-directories within individual module directories and the ZIP installers for GoCD Server
+and GoCD Agent are generated inside "**installers/target/distributions/zip/**".
 ```bash
-~/projects/go$ ls target
-agent
-agent-bootstrapper
+~/projects/go$ find . -name target -type d
+./addon-api/database/target
+./agent/target
 ...
-go-agent-14.1.0
-go-server-14.1.0
-...
-util
+./tfs-impl/target
+./util/target
+~/projects/go$ ls installers/target/distributions/zip/
+go-agent-16.7.0-3795.zip  go-server-16.7.0-3795.zip
 ```
 
 ### 2.1.2 Setup IntelliJ - to develop quicker

--- a/2/2.2.md
+++ b/2/2.2.md
@@ -73,7 +73,7 @@ Below are a set of steps that one would follow to achieve this
 - Run spec to assert that it fails.
     - Recompile without precompiling the assets, run this if you've changed any Java files
     ```bash
-    ~/projects/go $ SKIP_WAR=Y ./bn clean cruise:prepare
+    ~/projects/go $ ./gradlew clean cruise:prepare -PfastBuild
     ```
     - Run the spec file
     ```bash

--- a/2/2.2.md
+++ b/2/2.2.md
@@ -73,7 +73,7 @@ Below are a set of steps that one would follow to achieve this
 - Run spec to assert that it fails.
     - Recompile without precompiling the assets, run this if you've changed any Java files
     ```bash
-    ~/projects/go $ ./gradlew clean cruise:prepare -PfastBuild
+    ~/projects/go $ ./gradlew clean prepare -PfastBuild
     ```
     - Run the spec file
     ```bash

--- a/2/2.2.md
+++ b/2/2.2.md
@@ -71,21 +71,17 @@ Below are a set of steps that one would follow to achieve this
 ```
 
 - Run spec to assert that it fails.
-    - Recompile without precompiling the assets, run this if you've changed any Java files
-    ```bash
-    ~/projects/go $ ./gradlew clean prepare -PfastBuild
-    ```
     - Run the spec file
     ```bash
-    ~/projects/go $ rake --rakefile server/run_rspec_tests.rake 'spec_file[spec/views/shared/_application_nav_html_spec.rb]'
+    ~/projects/go $ ./gradlew rspec -Popts='--pattern spec/views/shared/_application_nav_html_spec.rb'
     ```
     - To run all the spec files do:
     ```bash
-    ~/projects/go $ rake --rakefile server/run_rspec_tests.rake spec
+    ~/projects/go $ ./gradlew rspec
     ```
     - To run a specific module/folder of files do:
     ```bash
-    ~/projects/go $ spec_module='**/views/shared' rake --rakefile server/run_rspec_tests.rake spec
+    ~/projects/go $ ./gradlew rspec -Popts='--pattern views/shared/*'
     ```
 
 - Fix the failing spec to match the expectation. In our use case, because localization in Go uses the ```localize.xml``` file to interpolate string values, we will make appropriate changes in that file.

--- a/2/2.4.md
+++ b/2/2.4.md
@@ -39,7 +39,7 @@ CREATE TRIGGER lastTransitionedTimeUpdate AFTER INSERT ON buildStateTransitions 
 If you now run
 
 ```bash
-./gradlew fatJar
+./gradlew prepare fatJar -PfastBuild
 ```
 
 and then bring up a Development Server, you will see that the migration runs.

--- a/2/2.4.md
+++ b/2/2.4.md
@@ -39,7 +39,7 @@ CREATE TRIGGER lastTransitionedTimeUpdate AFTER INSERT ON buildStateTransitions 
 If you now run
 
 ```bash
-./bn cruise:prepare
+./gradlew fatJar
 ```
 
 and then bring up a Development Server, you will see that the migration runs.


### PR DESCRIPTION
Replaced use of "./bn ..." with equivalent "./gradlew ..." per https://github.com/gocd/gocd/pull/2010.

**Testing performed**
Following 3 replacements exited normally:
```
$ ./gradlew clean agentGenericZip serverGenericZip
... truncated ...
BUILD SUCCESSFUL

Total time: 2 mins 30.08 secs

This build could be faster, please consider using the Gradle Daemon: https://docs.gradle.org/2.14/userguide/gradle_daemon.html
```

```
$ ./gradlew clean fatJar
... truncated ...
BUILD SUCCESSFUL

Total time: 2 mins 24.616 secs

This build could be faster, please consider using the Gradle Daemon: https://docs.gradle.org/2.14/userguide/gradle_daemon.html
```

```
$ ./gradlew fatJar
... truncated ...
BUILD SUCCESSFUL

Total time: 6.179 secs

This build could be faster, please consider using the Gradle Daemon: https://docs.gradle.org/2.14/userguide/gradle_daemon.html
```

Following replacement exited with failure:
```
$ ./gradlew clean cruise:prepare -PfastBuild
:buildSrc:compileJava UP-TO-DATE
:buildSrc:compileGroovy UP-TO-DATE
:buildSrc:processResources UP-TO-DATE
:buildSrc:classes UP-TO-DATE
:buildSrc:jar UP-TO-DATE
:buildSrc:assemble UP-TO-DATE
:buildSrc:compileTestJava UP-TO-DATE
:buildSrc:compileTestGroovy UP-TO-DATE
:buildSrc:processTestResources UP-TO-DATE
:buildSrc:testClasses UP-TO-DATE
:buildSrc:test UP-TO-DATE
:buildSrc:check UP-TO-DATE
:buildSrc:build UP-TO-DATE
You're attempting to partition files without specifying both GO_JOB_RUN_COUNT and GO_JOB_RUN_INDEX.

FAILURE: Build failed with an exception.

* What went wrong:
Project 'cruise' not found in root project 'gocd'.

* Try:
Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output.

BUILD FAILED

Total time: 5.024 secs
```