### PR TITLE
Added a note on plugin_settings page for Plugin Extensions that do not support get-plugin-settings API

### DIFF
--- a/writing_go_plugins/go_application_accessor/plugin_settings/plugin_settings.md
+++ b/writing_go_plugins/go_application_accessor/plugin_settings/plugin_settings.md
@@ -4,3 +4,6 @@
 
 Go Server currently exposes the following APIs:
 * [Get Plugin Settings](version_1_0/get_plugin_settings.md)
+
+Note that [Get Plugin Settings](version_1_0/get_plugin_settings.md) API is not supported by following type of plugin extensions:
+* [Task Extension](http://docs.go.cd/current/extension_points/task_extension.html)


### PR DESCRIPTION
![screen shot 2016-08-25 at 4 40 36 pm](https://cloud.githubusercontent.com/assets/15275847/17967048/c04ad580-6ae2-11e6-8d3a-6e27d142c3eb.png)
