### PR TITLE
Change classpath for IntelliJ agent/server setup

### DIFF
--- a/2/2.1.md
+++ b/2/2.1.md
@@ -62,14 +62,8 @@ Main Class: com.thoughtworks.go.server.DevelopmentServer
 VM options: -Xms512m -Xmx1024m -XX:PermSize=400m
 Working directory: <project-directory>/server
 Environment variables: GEM_PATH=;GEM_HOME=;
-Use classpath of module: development-server
+Use classpath of module: development-server_main
 ```
-
-Configuring IntelliJ IDEA *run-configuration*
-![](images/idea_run_configuration_development_server.png)
-
-Running *Development Server* from IntelliJ IDEA
-![](images/idea_run_configuration.png)
 
 ### 2.1.4 Running Development Agent via IntelliJ IDEA
 
@@ -79,7 +73,7 @@ The IDEA **Application** run-configuration can be setup using the values below:
 Name: Development Agent
 Main Class: com.thoughtworks.go.agent.DevelopmentAgent
 Working directory: <project-directory>/agent
-Use classpath of module: development-agent
+Use classpath of module: development-agent_main
 ```
 
 ### 2.1.5 Running RSpec tests from the command line


### PR DESCRIPTION
Steps to reproduce the issue:
1. Import gocd as existing project using gradle to import settings (using all default settings)
2. IntelliJ creates a project group called 'development-server' with three modules (development-server, development-server_main, development-server_test)
3. The documentation directs you to use 'development-server', but this inherits the project's compile output path, while 'development-server_main' uses the module's compile output path

This change just updates the documentation to point to the correct module, and removes the incorrect images of the project configuration, which didn't add much value to the documentation.