### PR TITLE
Update Git version to 1.9+

### DIFF
--- a/2/2.1.md
+++ b/2/2.1.md
@@ -5,7 +5,7 @@
 GoCD requires the following software packages to build
 
 - JDK 8 (OpenJDK or Oracle)
-- Git (1.7+)
+- Git (1.9+)
 - NodeJS 6.x (https://nodejs.org/en/download/)
 - yarn package manager (https://yarnpkg.com/en/docs/install)
 


### PR DESCRIPTION
As of release 17.2, support for git versions older than 1.9 was removed.