### PR TITLE
Fixing minor issue with writing plugins overview page

### DIFF
--- a/source/writing_go_plugins/overview.md
+++ b/source/writing_go_plugins/overview.md
@@ -22,8 +22,8 @@ In order to support existing plugins and provide enough time to the plugin autho
 
 JSON message based plugin API has been described in further details [here](json_message_based_plugin_api.md).
 
-<a name="plugin-api-jar"></a>
-<a name="plugin-api-javadocs"></a>
+<a name="plugin-api-jar"> </a>
+<a name="plugin-api-javadocs"> </a>
 ## Plugin API jar and javadocs
 
 You can find the latest API jar file with its associated sources and javadocs on [Maven Central](http://search.maven.org/#search%7Cga%7C1%7Cgo-plugin-api).


### PR DESCRIPTION
This is a minor fix to the writing plugin's overview page. Specifically, these changes remove a tailing `</a>` from the page

Before the changes:
<img width="992" alt="before" src="https://user-images.githubusercontent.com/5726224/33400795-05324a7c-d50c-11e7-8e36-479b650e738e.png">

After the changes:
<img width="983" alt="after" src="https://user-images.githubusercontent.com/5726224/33400800-0796a042-d50c-11e7-8e76-7a4109794505.png">


