### PR TITLE
Switch from legacy Gitbook to fork Honkit

### DIFF
--- a/.github/workflows/build_and_publish.yml
+++ b/.github/workflows/build_and_publish.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Install node
         uses: actions/setup-node@v2
         with:
-          node-version: '14.3.0'
+          node-version: 14.18.1
       - name: Run the build
         run: |
           bundle install
@@ -42,7 +42,7 @@ jobs:
       - name: Install node
         uses: actions/setup-node@v2
         with:
-          node-version: '14.3.0'
+          node-version: 14.18.1
       - name: Set up user in git config
         run: |
           git config --global user.name "github-actions"
@@ -73,7 +73,7 @@ jobs:
       - name: Install node
         uses: actions/setup-node@v2
         with:
-          node-version: '14.3.0'
+          node-version: 14.18.1
       - name: Upload to S3
         run: |
           bundle install

--- a/.github/workflows/pr_workflow.yml
+++ b/.github/workflows/pr_workflow.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Install node
         uses: actions/setup-node@v2
         with:
-          node-version: '14.3.0'
+          node-version: 14.18.1
       - name: Run the build
         run: |
           bundle install

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,6 +1,5 @@
 module.exports = function(grunt) {
 
-var path = require("path");
   grunt.initConfig({
     pkg: grunt.file.readJSON('package.json'),
     docs: {

--- a/README.md
+++ b/README.md
@@ -4,11 +4,10 @@ This repository contains the developer documentation for [GoCD](https://www.gocd
 
 ## Build and run locally
 
-### Install and configure [gitbook-cli](https://github.com/GitbookIO/gitbook-cli)
+### Install [honkit](https://github.com/honkit/honkit)
 
 ```
 $ npm install
-$ npm run init-gitbook
 ```
 
 ### Serve the documentation locally

--- a/book.json
+++ b/book.json
@@ -13,15 +13,14 @@
       "all": "https://www.gocd.org"
     }
   },
-  "gitbook": "3.2.2",
+  "honkit": ">= 3.2.2",
   "plugins": [
-    "highlight@2.0.3",
-    "anchors@0.7.1",
-    "ga@1.0.1",
-    "redirect@0.0.7",
-    "collapsible-menu@1.0.3"
-  ]
-  ,
+    "highlight",
+    "anchors",
+    "ga",
+    "redirect",
+    "collapsible-menu"
+  ],
   "pluginsConfig": {
     "ga": {
       "token": "UA-48357651-4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,17 +4,185 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@asciidoctor/core": {
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/@asciidoctor/core/-/core-2.2.5.tgz",
+      "integrity": "sha512-jtQPQ5EivgFbwvSyGKas4ANnMGGHPbmu791H9xrZKooA65JNI30jM2em5MvUXTTetSPgb6saUf+PJibEuSB6uw==",
+      "requires": {
+        "asciidoctor-opal-runtime": "0.3.3",
+        "unxhr": "1.0.1"
+      }
+    },
+    "@honkit/asciidoc": {
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/@honkit/asciidoc/-/asciidoc-3.7.0.tgz",
+      "integrity": "sha512-pa0Uy0HFuRBY5NmATPTJTmiffP8kosJoN8Ilc+WgJNxZdG146LcDQ5KroggT5/kZDHZBFlAyuNFSbMRe1dgV+Q==",
+      "requires": {
+        "@honkit/html": "^3.7.0",
+        "asciidoctor": "^2.2.0",
+        "lodash": "^4.13.1"
+      }
+    },
+    "@honkit/honkit-plugin-highlight": {
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/@honkit/honkit-plugin-highlight/-/honkit-plugin-highlight-3.7.0.tgz",
+      "integrity": "sha512-8qkpEnnYfFRtL+WpFSVSxwYQD0M28mRRxFULBXyQRbR2wBhMS9neKZ2uImgPKa7+tlhQsD+PvJnxfN1rslhbhw==",
+      "requires": {
+        "highlight.js": "^10.7.1"
+      },
+      "dependencies": {
+        "highlight.js": {
+          "version": "10.7.3",
+          "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.7.3.tgz",
+          "integrity": "sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A=="
+        }
+      }
+    },
+    "@honkit/honkit-plugin-theme-default": {
+      "version": "3.6.20",
+      "resolved": "https://registry.npmjs.org/@honkit/honkit-plugin-theme-default/-/honkit-plugin-theme-default-3.6.20.tgz",
+      "integrity": "sha512-1JVaZk/8TYuauNEse+uDaZjje/Za1CwElHLuMZx5K9IZy9isqD/du/AHxESprIypMzxD6DFr0jsHx2F+C7l6Fg=="
+    },
+    "@honkit/html": {
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/@honkit/html/-/html-3.7.0.tgz",
+      "integrity": "sha512-+D+BItUys90LTmLnU2dyqtnJoLKfv+ge+Qcj7x0LBMxGfL8wkY4GJD2rS+J+y+cyUPmueTxjvg2yoli61KvodQ==",
+      "requires": {
+        "cheerio": "^0.20.0",
+        "lodash": "^4.13.1",
+        "q": "^1.1.2"
+      },
+      "dependencies": {
+        "cheerio": {
+          "version": "0.20.0",
+          "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-0.20.0.tgz",
+          "integrity": "sha1-XHEPK6uVZTJyhCugHG6mGzVF7DU=",
+          "requires": {
+            "css-select": "~1.2.0",
+            "dom-serializer": "~0.1.0",
+            "entities": "~1.1.1",
+            "htmlparser2": "~3.8.1",
+            "jsdom": "^7.0.2",
+            "lodash": "^4.1.0"
+          }
+        },
+        "domhandler": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.3.0.tgz",
+          "integrity": "sha1-LeWaCCLVAn+r/28DLCsloqir5zg=",
+          "requires": {
+            "domelementtype": "1"
+          }
+        },
+        "htmlparser2": {
+          "version": "3.8.3",
+          "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.8.3.tgz",
+          "integrity": "sha1-mWwosZFRaovoZQGn15dX5ccMEGg=",
+          "requires": {
+            "domelementtype": "1",
+            "domhandler": "2.3",
+            "domutils": "1.5",
+            "entities": "1.0",
+            "readable-stream": "1.1"
+          },
+          "dependencies": {
+            "entities": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/entities/-/entities-1.0.0.tgz",
+              "integrity": "sha1-sph6o4ITR/zeZCsk/fyeT7cSvyY="
+            }
+          }
+        },
+        "readable-stream": {
+          "version": "1.1.14",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+          "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
+            "isarray": "0.0.1",
+            "string_decoder": "~0.10.x"
+          }
+        },
+        "string_decoder": {
+          "version": "0.10.31",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+        }
+      }
+    },
+    "@honkit/markdown-legacy": {
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/@honkit/markdown-legacy/-/markdown-legacy-3.7.0.tgz",
+      "integrity": "sha512-iLgLszjG5wVzsOvgpZBi6S/lnWyNq20uMrWfDYapgW8U0feXo7L6i7KAJSqp8EBKSs7Ae+v1q2SDjZfyikJtYQ==",
+      "requires": {
+        "@honkit/html": "^3.7.0",
+        "kramed": "0.5.6",
+        "lodash": "^4.13.1"
+      }
+    },
+    "a-sync-waterfall": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/a-sync-waterfall/-/a-sync-waterfall-1.0.1.tgz",
+      "integrity": "sha512-RYTOHHdWipFUliRFMCS4X2Yn2X8M87V/OpSqWzKKOGhzqyUxzyVmhHDH9sAvG+ZuQf/TAOFsLCpMw09I1ufUnA=="
+    },
+    "abab": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/abab/-/abab-1.0.4.tgz",
+      "integrity": "sha1-X6rZwsB/YN12dw9xzwJbYqY8/U4=",
+      "optional": true
+    },
     "abbrev": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
       "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
     },
-    "ansi-styles": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+    "acorn": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-2.7.0.tgz",
+      "integrity": "sha1-q259nYhqrKiwhbwzEreaGYQz8Oc=",
+      "optional": true
+    },
+    "acorn-globals": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-1.0.9.tgz",
+      "integrity": "sha1-VbtemGkVB7dFedBRNBMhfDgMVM8=",
+      "optional": true,
       "requires": {
-        "color-convert": "^1.9.0"
+        "acorn": "^2.1.0"
+      }
+    },
+    "ajv": {
+      "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "requires": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      }
+    },
+    "ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="
+    },
+    "ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "requires": {
+        "color-convert": "^2.0.1"
+      }
+    },
+    "anymatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.2.tgz",
+      "integrity": "sha512-P43ePfOAIupkguHUycrc4qJ9kz8ZiuOUijaETwX7THt0Y/GNK7v0aa8rY816xWjZ7rJdA5XdMcpVFTKMq+RvWg==",
+      "requires": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
       }
     },
     "argparse": {
@@ -23,124 +191,127 @@
       "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
       "requires": {
         "sprintf-js": "~1.0.2"
-      },
-      "dependencies": {
-        "sprintf-js": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-          "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
-        }
       }
     },
-    "arr-diff": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
-      "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA="
-    },
-    "arr-flatten": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
-      "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg=="
-    },
-    "arr-union": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
-      "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ="
+    "array-difference": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/array-difference/-/array-difference-0.0.1.tgz",
+      "integrity": "sha1-x8r9m1SzXrgvcue6MZ6Tij/TKwc="
     },
     "array-each": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/array-each/-/array-each-1.0.1.tgz",
       "integrity": "sha1-p5SvDAWrF1KEbudTofIRoFugxE8="
     },
-    "array-find-index": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
-      "integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E="
-    },
     "array-slice": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/array-slice/-/array-slice-1.1.0.tgz",
       "integrity": "sha512-B1qMD3RBP7O8o0H2KbrXDyB0IccejMF15+87Lvlor12ONPRHP6gTjXMNkt/d3ZuOGbAe66hFmaCfECI24Ufp6w=="
     },
-    "array-unique": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
-      "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg="
+    "asap": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+      "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
     },
-    "assign-symbols": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
-      "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c="
-    },
-    "async": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-      "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
-    },
-    "atob": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
-      "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg=="
-    },
-    "balanced-match": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
-    },
-    "base": {
-      "version": "0.11.2",
-      "resolved": "https://registry.npmjs.org/base/-/base-0.11.2.tgz",
-      "integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
+    "asciidoctor": {
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/asciidoctor/-/asciidoctor-2.2.5.tgz",
+      "integrity": "sha512-rrmCK34faw+w+xGFQggjwPB0/pcISnwOXaulfJvn7j4Nm0bFwz+x4tG3ZANIA9+9i6Csex/PO0fSLBO8CSdzVA==",
       "requires": {
-        "cache-base": "^1.0.1",
-        "class-utils": "^0.3.5",
-        "component-emitter": "^1.2.1",
-        "define-property": "^1.0.0",
-        "isobject": "^3.0.1",
-        "mixin-deep": "^1.2.0",
-        "pascalcase": "^0.1.1"
+        "@asciidoctor/cli": "3.4.0",
+        "@asciidoctor/core": "2.2.5"
       },
       "dependencies": {
-        "define-property": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
-          "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+        "@asciidoctor/cli": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/@asciidoctor/cli/-/cli-3.4.0.tgz",
+          "integrity": "sha512-jOtxA0I6zB+6z+GGwm9+xhlmGTqCTkFPE902L6fauFlE6v7LxjhLYNxvjDVyn0zMrFLybvoSRcAnM3DcticNoQ==",
           "requires": {
-            "is-descriptor": "^1.0.0"
-          }
-        },
-        "is-accessor-descriptor": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
-          "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
-          "requires": {
-            "kind-of": "^6.0.0"
-          }
-        },
-        "is-data-descriptor": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
-          "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
-          "requires": {
-            "kind-of": "^6.0.0"
-          }
-        },
-        "is-descriptor": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
-          "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
-          "requires": {
-            "is-accessor-descriptor": "^1.0.0",
-            "is-data-descriptor": "^1.0.0",
-            "kind-of": "^6.0.2"
+            "yargs": "15.3.1"
           }
         }
       }
+    },
+    "asciidoctor-opal-runtime": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/asciidoctor-opal-runtime/-/asciidoctor-opal-runtime-0.3.3.tgz",
+      "integrity": "sha512-/CEVNiOia8E5BMO9FLooo+Kv18K4+4JBFRJp8vUy/N5dMRAg+fRNV4HA+o6aoSC79jVU/aT5XvUpxSxSsTS8FQ==",
+      "requires": {
+        "glob": "7.1.3",
+        "unxhr": "1.0.1"
+      }
+    },
+    "asn1": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.6.tgz",
+      "integrity": "sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==",
+      "requires": {
+        "safer-buffer": "~2.1.0"
+      }
+    },
+    "assert-plus": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+    },
+    "async": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.2.tgz",
+      "integrity": "sha512-H0E+qZaDEfx/FY4t7iLRv1W2fFI6+pyCeTw1uN20AQPiwqwM6ojPxHxdLv4z8hi2DtnW9BOckSspLucW7pIE5g=="
+    },
+    "asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
+    },
+    "aws-sign2": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
+    },
+    "aws4": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.11.0.tgz",
+      "integrity": "sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA=="
+    },
+    "balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
+    },
+    "base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
     },
     "bash-color": {
       "version": "0.0.4",
       "resolved": "https://registry.npmjs.org/bash-color/-/bash-color-0.0.4.tgz",
       "integrity": "sha1-6b6M4zVAytpIgXaMWb1jhlc26RM="
+    },
+    "bcrypt-pbkdf": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+      "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
+      "requires": {
+        "tweetnacl": "^0.14.3"
+      }
+    },
+    "binary-extensions": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
+      "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA=="
+    },
+    "body": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/body/-/body-5.1.0.tgz",
+      "integrity": "sha1-5LoM5BCkaTYyM2dgnstOZVMSUGk=",
+      "requires": {
+        "continuable-cache": "^0.3.1",
+        "error": "^7.0.0",
+        "raw-body": "~1.1.0",
+        "safe-json-parse": "~1.0.1"
+      }
     },
     "boolbase": {
       "version": "1.0.0",
@@ -157,61 +328,36 @@
       }
     },
     "braces": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
-      "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
       "requires": {
-        "arr-flatten": "^1.1.0",
-        "array-unique": "^0.3.2",
-        "extend-shallow": "^2.0.1",
-        "fill-range": "^4.0.0",
-        "isobject": "^3.0.1",
-        "repeat-element": "^1.1.2",
-        "snapdragon": "^0.8.1",
-        "snapdragon-node": "^2.0.1",
-        "split-string": "^3.0.2",
-        "to-regex": "^3.0.1"
-      },
-      "dependencies": {
-        "extend-shallow": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-          "requires": {
-            "is-extendable": "^0.1.0"
-          }
-        }
+        "fill-range": "^7.0.1"
       }
     },
-    "cache-base": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
-      "integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
+    "buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
       "requires": {
-        "collection-visit": "^1.0.0",
-        "component-emitter": "^1.2.1",
-        "get-value": "^2.0.6",
-        "has-value": "^1.0.0",
-        "isobject": "^3.0.1",
-        "set-value": "^2.0.0",
-        "to-object-path": "^0.3.0",
-        "union-value": "^1.0.0",
-        "unset-value": "^1.0.0"
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
       }
+    },
+    "bytes": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-1.0.0.tgz",
+      "integrity": "sha1-NWnt6Lo0MV+rmcPpLLBMciDeH6g="
     },
     "camelcase": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
-      "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8="
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="
     },
-    "camelcase-keys": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
-      "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
-      "requires": {
-        "camelcase": "^2.0.0",
-        "map-obj": "^1.0.0"
-      }
+    "caseless": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
     },
     "chalk": {
       "version": "2.4.2",
@@ -221,6 +367,34 @@
         "ansi-styles": "^3.2.1",
         "escape-string-regexp": "^1.0.5",
         "supports-color": "^5.3.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "color-convert": {
+          "version": "1.9.3",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+          "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+          "requires": {
+            "color-name": "1.1.3"
+          }
+        },
+        "color-name": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+          "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+        },
+        "escape-string-regexp": {
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+        }
       }
     },
     "cheerio": {
@@ -246,93 +420,140 @@
         "lodash.some": "^4.4.0"
       }
     },
-    "class-utils": {
-      "version": "0.3.6",
-      "resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
-      "integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
+    "chokidar": {
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.2.tgz",
+      "integrity": "sha512-ekGhOnNVPgT77r4K/U3GDhu+FQ2S8TnK/s2KbIGXi0SZWuwkZ2QNyfWdZW+TVfn84DpEP7rLeCt2UI6bJ8GwbQ==",
       "requires": {
-        "arr-union": "^3.1.0",
-        "define-property": "^0.2.5",
-        "isobject": "^3.0.0",
-        "static-extend": "^0.1.1"
-      },
-      "dependencies": {
-        "define-property": {
-          "version": "0.2.5",
-          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
-          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-          "requires": {
-            "is-descriptor": "^0.1.0"
-          }
-        }
+        "anymatch": "~3.1.2",
+        "braces": "~3.0.2",
+        "fsevents": "~2.3.2",
+        "glob-parent": "~5.1.2",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.6.0"
       }
     },
     "clean-css": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-5.1.5.tgz",
-      "integrity": "sha512-9dr/cU/LjMpU57PXlSvDkVRh0rPxJBXiBtD0+SgYt8ahTCsXtfKjCkNYgIoTC6mBg8CFr5EKhW3DKCaGMUbUfQ==",
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-5.2.2.tgz",
+      "integrity": "sha512-/eR8ru5zyxKzpBLv9YZvMXgTSSQn7AdkMItMYynsFgGwTveCRVam9IUPFloE85B4vAIj05IuKmmEoV7/AQjT0w==",
       "requires": {
         "source-map": "~0.6.0"
-      },
-      "dependencies": {
-        "source-map": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
-        }
       }
     },
-    "coffeescript": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/coffeescript/-/coffeescript-1.10.0.tgz",
-      "integrity": "sha1-56qDAZF+9iGzXYo580jc3R234z4="
-    },
-    "collection-visit": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
-      "integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
+    "cliui": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
+      "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
       "requires": {
-        "map-visit": "^1.0.0",
-        "object-visit": "^1.0.0"
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^6.2.0"
       }
     },
     "color-convert": {
-      "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
       "requires": {
-        "color-name": "1.1.3"
+        "color-name": "~1.1.4"
       }
     },
     "color-name": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
     },
     "colors": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
       "integrity": "sha1-FopHAXVran9RoSzgyXv6KMCE7WM="
     },
-    "commander": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
-      "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ=="
+    "combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "requires": {
+        "delayed-stream": "~1.0.0"
+      }
     },
-    "component-emitter": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
-      "integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg=="
+    "commander": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-5.1.0.tgz",
+      "integrity": "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg=="
     },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
-    "copy-descriptor": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
-      "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40="
+    "continuable-cache": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/continuable-cache/-/continuable-cache-0.3.1.tgz",
+      "integrity": "sha1-vXJ6f67XfnH/OYWskzUakSczrQ8="
+    },
+    "core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="
+    },
+    "cp": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/cp/-/cp-0.2.0.tgz",
+      "integrity": "sha1-oIdBg6CeiF63J5JYKraM45MrE10="
+    },
+    "cpr": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/cpr/-/cpr-3.0.1.tgz",
+      "integrity": "sha1-uaVQOLfNgaNcF7l2GJW9hJau8eU=",
+      "requires": {
+        "graceful-fs": "^4.1.5",
+        "minimist": "^1.2.0",
+        "mkdirp": "~0.5.1",
+        "rimraf": "^2.5.4"
+      },
+      "dependencies": {
+        "mkdirp": {
+          "version": "0.5.5",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+          "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
+          "requires": {
+            "minimist": "^1.2.5"
+          }
+        }
+      }
+    },
+    "crc": {
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/crc/-/crc-3.8.0.tgz",
+      "integrity": "sha512-iX3mfgcTMIq3ZKLIsVFAbv7+Mc10kxabAGQb8HvjA1o3T1PIYprbakQ65d3I+2HGHt6nSKkM9PYjgoJO2KcFBQ==",
+      "requires": {
+        "buffer": "^5.1.0"
+      }
+    },
+    "cross-spawn": {
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+      "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+      "requires": {
+        "nice-try": "^1.0.4",
+        "path-key": "^2.0.1",
+        "semver": "^5.5.0",
+        "shebang-command": "^1.2.0",
+        "which": "^1.2.9"
+      },
+      "dependencies": {
+        "which": {
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+          "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+          "requires": {
+            "isexe": "^2.0.0"
+          }
+        }
+      }
     },
     "css-select": {
       "version": "1.2.0",
@@ -350,22 +571,42 @@
       "resolved": "https://registry.npmjs.org/css-what/-/css-what-2.1.3.tgz",
       "integrity": "sha512-a+EPoD+uZiNfh+5fxw2nO9QwFa6nJe2Or35fGY6Ipw1R3R4AGz1d1TEZrCegvw2YTmZ0jXirGYlzxxpYSHwpEg=="
     },
-    "currently-unhandled": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
-      "integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
+    "cssom": {
+      "version": "0.3.8",
+      "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.8.tgz",
+      "integrity": "sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg==",
+      "optional": true
+    },
+    "cssstyle": {
+      "version": "0.2.37",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-0.2.37.tgz",
+      "integrity": "sha1-VBCXI0yyUTyDzu06zdwn/yeYfVQ=",
+      "optional": true,
       "requires": {
-        "array-find-index": "^1.0.1"
+        "cssom": "0.3.x"
+      }
+    },
+    "dashdash": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+      "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+      "requires": {
+        "assert-plus": "^1.0.0"
+      }
+    },
+    "datauri": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/datauri/-/datauri-2.0.0.tgz",
+      "integrity": "sha512-zS2HSf9pI5XPlNZgIqJg/wCJpecgU/HA6E/uv2EfaWnW1EiTGLfy/EexTIsC9c99yoCOTXlqeeWk4FkCSuO3/g==",
+      "requires": {
+        "image-size": "^0.7.3",
+        "mimer": "^1.0.0"
       }
     },
     "dateformat": {
-      "version": "1.0.12",
-      "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.12.tgz",
-      "integrity": "sha1-nxJLZ1lMk3/3BpMuSmQsyo27/uk=",
-      "requires": {
-        "get-stdin": "^4.0.1",
-        "meow": "^3.3.0"
-      }
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-3.0.3.tgz",
+      "integrity": "sha512-jyCETtSl3VMZMWeRo7iY1FL19ges1t55hMo5yaam4Jrsm5EPL89UQkoQRyiI+Yf4k8r2ZpdngkV8hr1lIdjb3Q=="
     },
     "debug": {
       "version": "2.6.9",
@@ -373,59 +614,69 @@
       "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
       "requires": {
         "ms": "2.0.0"
+      },
+      "dependencies": {
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+        }
       }
+    },
+    "debuglog": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/debuglog/-/debuglog-1.0.1.tgz",
+      "integrity": "sha1-qiT/uaw9+aI1GDfPstJ5NgzXhJI="
     },
     "decamelize": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
       "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
     },
-    "decode-uri-component": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
-      "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU="
+    "deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA=="
     },
-    "define-property": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
-      "integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
-      "requires": {
-        "is-descriptor": "^1.0.2",
-        "isobject": "^3.0.1"
-      },
-      "dependencies": {
-        "is-accessor-descriptor": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
-          "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
-          "requires": {
-            "kind-of": "^6.0.0"
-          }
-        },
-        "is-data-descriptor": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
-          "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
-          "requires": {
-            "kind-of": "^6.0.0"
-          }
-        },
-        "is-descriptor": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
-          "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
-          "requires": {
-            "is-accessor-descriptor": "^1.0.0",
-            "is-data-descriptor": "^1.0.0",
-            "kind-of": "^6.0.2"
-          }
-        }
-      }
+    "deep-is": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+      "optional": true
+    },
+    "delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+    },
+    "depd": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
+      "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak="
+    },
+    "destroy": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
+      "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
     },
     "detect-file": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/detect-file/-/detect-file-1.0.0.tgz",
       "integrity": "sha1-8NZtA2cqglyxtzvbP+YjEMjlUrc="
+    },
+    "dezalgo": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.3.tgz",
+      "integrity": "sha1-f3Qt4Gb8dIvI24IFad3c5Jvw1FY=",
+      "requires": {
+        "asap": "^2.0.0",
+        "wrappy": "1"
+      }
+    },
+    "direction": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/direction/-/direction-0.1.5.tgz",
+      "integrity": "sha1-zl15f5fib4vnvv9T99xA4cGp7Ew="
     },
     "dom-serializer": {
       "version": "0.1.1",
@@ -463,28 +714,88 @@
       "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.2.tgz",
       "integrity": "sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg=="
     },
+    "ecc-jsbn": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
+      "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
+      "requires": {
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.1.0"
+      }
+    },
+    "ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
+    },
+    "emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+    },
+    "encodeurl": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
+      "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k="
+    },
     "entities": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.2.tgz",
       "integrity": "sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w=="
     },
-    "error-ex": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
-      "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
+    "error": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/error/-/error-7.0.2.tgz",
+      "integrity": "sha1-pfdf/02ZJhJt2sDqXcOOaJFTywI=",
       "requires": {
-        "is-arrayish": "^0.2.1"
+        "string-template": "~0.2.1",
+        "xtend": "~4.0.0"
       }
     },
+    "escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg="
+    },
     "escape-string-regexp": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="
+    },
+    "escodegen": {
+      "version": "1.14.3",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.14.3.tgz",
+      "integrity": "sha512-qFcX0XJkdg+PB3xjZZG/wKSuT1PnQWx57+TVSjIMmILd2yC/6ByYElPwJnslDsuWuSAp4AwJGumarAAmJch5Kw==",
+      "optional": true,
+      "requires": {
+        "esprima": "^4.0.1",
+        "estraverse": "^4.2.0",
+        "esutils": "^2.0.2",
+        "optionator": "^0.8.1",
+        "source-map": "~0.6.1"
+      }
     },
     "esprima": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
       "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
+    },
+    "estraverse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
+      "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
+      "optional": true
+    },
+    "esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "optional": true
+    },
+    "etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc="
     },
     "eventemitter2": {
       "version": "0.4.14",
@@ -495,38 +806,6 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
       "integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw="
-    },
-    "expand-brackets": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
-      "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
-      "requires": {
-        "debug": "^2.3.3",
-        "define-property": "^0.2.5",
-        "extend-shallow": "^2.0.1",
-        "posix-character-classes": "^0.1.0",
-        "regex-not": "^1.0.0",
-        "snapdragon": "^0.8.1",
-        "to-regex": "^3.0.1"
-      },
-      "dependencies": {
-        "define-property": {
-          "version": "0.2.5",
-          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
-          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-          "requires": {
-            "is-descriptor": "^0.1.0"
-          }
-        },
-        "extend-shallow": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-          "requires": {
-            "is-extendable": "^0.1.0"
-          }
-        }
-      }
     },
     "expand-tilde": {
       "version": "2.0.2",
@@ -541,82 +820,33 @@
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
     },
-    "extend-shallow": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
-      "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
-      "requires": {
-        "assign-symbols": "^1.0.0",
-        "is-extendable": "^1.0.1"
-      },
-      "dependencies": {
-        "is-extendable": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
-          "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
-          "requires": {
-            "is-plain-object": "^2.0.4"
-          }
-        }
-      }
+    "extsprintf": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
     },
-    "extglob": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
-      "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
+    "fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
+    },
+    "fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
+    },
+    "fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
+      "optional": true
+    },
+    "faye-websocket": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.10.0.tgz",
+      "integrity": "sha1-TkkvjQTftviQA1B/btvy1QHnxvQ=",
       "requires": {
-        "array-unique": "^0.3.2",
-        "define-property": "^1.0.0",
-        "expand-brackets": "^2.1.4",
-        "extend-shallow": "^2.0.1",
-        "fragment-cache": "^0.2.1",
-        "regex-not": "^1.0.0",
-        "snapdragon": "^0.8.1",
-        "to-regex": "^3.0.1"
-      },
-      "dependencies": {
-        "define-property": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
-          "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
-          "requires": {
-            "is-descriptor": "^1.0.0"
-          }
-        },
-        "extend-shallow": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-          "requires": {
-            "is-extendable": "^0.1.0"
-          }
-        },
-        "is-accessor-descriptor": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
-          "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
-          "requires": {
-            "kind-of": "^6.0.0"
-          }
-        },
-        "is-data-descriptor": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
-          "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
-          "requires": {
-            "kind-of": "^6.0.0"
-          }
-        },
-        "is-descriptor": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
-          "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
-          "requires": {
-            "is-accessor-descriptor": "^1.0.0",
-            "is-data-descriptor": "^1.0.0",
-            "kind-of": "^6.0.2"
-          }
-        }
+        "websocket-driver": ">=0.5.1"
       }
     },
     "figures": {
@@ -625,36 +855,30 @@
       "integrity": "sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==",
       "requires": {
         "escape-string-regexp": "^1.0.5"
-      }
-    },
-    "fill-range": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
-      "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
-      "requires": {
-        "extend-shallow": "^2.0.1",
-        "is-number": "^3.0.0",
-        "repeat-string": "^1.6.1",
-        "to-regex-range": "^2.1.0"
       },
       "dependencies": {
-        "extend-shallow": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-          "requires": {
-            "is-extendable": "^0.1.0"
-          }
+        "escape-string-regexp": {
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
         }
       }
     },
-    "find-up": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
-      "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+    "fill-range": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
       "requires": {
-        "path-exists": "^2.0.0",
-        "pinkie-promise": "^2.0.0"
+        "to-regex-range": "^5.0.1"
+      }
+    },
+    "find-up": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "requires": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
       }
     },
     "findup-sync": {
@@ -696,6 +920,31 @@
       "resolved": "https://registry.npmjs.org/flagged-respawn/-/flagged-respawn-1.0.1.tgz",
       "integrity": "sha512-lNaHNVymajmk0OJMBn8fVUAU1BtDeKIqKoVhk4xAALB57aALg6b4W0MfJ/cUE0g9YBXy5XhSlPIpYIJ7HaY/3Q=="
     },
+    "flat-cache": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-2.0.1.tgz",
+      "integrity": "sha512-LoQe6yDuUMDzQAEH8sgmh4Md6oZnc/7PjtwjNFSzveXqSHt6ka9fPBuso7IGf9Rz4uqnSnWiFH2B/zj24a5ReA==",
+      "requires": {
+        "flatted": "^2.0.0",
+        "rimraf": "2.6.3",
+        "write": "1.0.3"
+      },
+      "dependencies": {
+        "rimraf": {
+          "version": "2.6.3",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+          "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        }
+      }
+    },
+    "flatted": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.2.tgz",
+      "integrity": "sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA=="
+    },
     "for-in": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
@@ -709,22 +958,32 @@
         "for-in": "^1.0.1"
       }
     },
-    "fragment-cache": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
-      "integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
+    "forever-agent": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
+    },
+    "form-data": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
+      "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
       "requires": {
-        "map-cache": "^0.2.2"
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.6",
+        "mime-types": "^2.1.12"
       }
     },
-    "fs-extra": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-3.0.1.tgz",
-      "integrity": "sha1-N5TzeMWLNC6n27sjCVEJxLO2IpE=",
+    "fresh": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+      "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac="
+    },
+    "front-matter": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/front-matter/-/front-matter-2.3.0.tgz",
+      "integrity": "sha1-cgOviWzjV+4E4qpFFp6pHtf2dQQ=",
       "requires": {
-        "graceful-fs": "^4.1.2",
-        "jsonfile": "^3.0.0",
-        "universalify": "^0.1.0"
+        "js-yaml": "^3.10.0"
       }
     },
     "fs.realpath": {
@@ -732,37 +991,33 @@
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
     },
-    "get-stdin": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
-      "integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4="
+    "fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "optional": true
     },
-    "get-value": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
-      "integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg="
+    "function-bind": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+    },
+    "get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="
     },
     "getobject": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/getobject/-/getobject-0.1.0.tgz",
-      "integrity": "sha1-BHpEl4n6Fg0Bj1SG7ZEyC27HiFw="
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/getobject/-/getobject-1.0.2.tgz",
+      "integrity": "sha512-2zblDBaFcb3rB4rF77XVnuINOE2h2k/OnqXAiy0IrTxUfV1iFp3la33oAQVY9pCpWU268WFYVt2t71hlMuLsOg=="
     },
-    "gitbook-cli": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/gitbook-cli/-/gitbook-cli-2.3.2.tgz",
-      "integrity": "sha512-eyGtkY7jKHhmgpfuvgAP5fZcUob/FBz4Ld0aLRdEmiTrS1RklimN9epzPp75dd4MWpGhYvSbiwxnpyLiv1wh6A==",
+    "getpass": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+      "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
       "requires": {
-        "bash-color": "0.0.4",
-        "commander": "2.11.0",
-        "fs-extra": "3.0.1",
-        "lodash": "4.17.4",
-        "npm": "5.1.0",
-        "npmi": "1.0.1",
-        "optimist": "0.6.1",
-        "q": "1.5.0",
-        "semver": "5.3.0",
-        "tmp": "0.0.31",
-        "user-home": "2.0.0"
+        "assert-plus": "^1.0.0"
       }
     },
     "gitbook-plugin-anchors": {
@@ -779,6 +1034,11 @@
       "resolved": "https://registry.npmjs.org/gitbook-plugin-collapsible-menu/-/gitbook-plugin-collapsible-menu-1.0.3.tgz",
       "integrity": "sha1-bSdlFouqplmeAtFdeKimfMgQgos="
     },
+    "gitbook-plugin-fontsettings": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/gitbook-plugin-fontsettings/-/gitbook-plugin-fontsettings-2.0.0.tgz",
+      "integrity": "sha1-g1+QCuPdERCG/n7UQl7j3gJIYas="
+    },
     "gitbook-plugin-ga": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/gitbook-plugin-ga/-/gitbook-plugin-ga-1.0.1.tgz",
@@ -792,6 +1052,21 @@
         "highlight.js": "9.8.0"
       }
     },
+    "gitbook-plugin-livereload": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/gitbook-plugin-livereload/-/gitbook-plugin-livereload-0.0.1.tgz",
+      "integrity": "sha1-wMncb1X4L8JPl1MrJSh6u7tBa5Y="
+    },
+    "gitbook-plugin-lunr": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gitbook-plugin-lunr/-/gitbook-plugin-lunr-1.2.0.tgz",
+      "integrity": "sha1-8+gOx2US+9t16wUkqoK43/EqUKs=",
+      "requires": {
+        "gitbook-plugin-search": "*",
+        "html-entities": "1.2.0",
+        "lunr": "0.5.12"
+      }
+    },
     "gitbook-plugin-redirect": {
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/gitbook-plugin-redirect/-/gitbook-plugin-redirect-0.0.7.tgz",
@@ -800,22 +1075,35 @@
         "valid-url": "*"
       }
     },
+    "gitbook-plugin-search": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/gitbook-plugin-search/-/gitbook-plugin-search-2.2.1.tgz",
+      "integrity": "sha1-bSW1p3aZD6mP39+jfeMx944PaxM="
+    },
     "github-slugid": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/github-slugid/-/github-slugid-1.0.1.tgz",
       "integrity": "sha1-vM3QgVv61p2KNZ+k/WWUfWBuw8A="
     },
     "glob": {
-      "version": "7.0.6",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.0.6.tgz",
-      "integrity": "sha1-IRuvr0nlJbjNkyYNFKsTYVKz9Xo=",
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
+      "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
       "requires": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
         "inherits": "2",
-        "minimatch": "^3.0.2",
+        "minimatch": "^3.0.4",
         "once": "^1.3.0",
         "path-is-absolute": "^1.0.0"
+      }
+    },
+    "glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "requires": {
+        "is-glob": "^4.0.1"
       }
     },
     "global-modules": {
@@ -828,6 +1116,14 @@
         "resolve-dir": "^1.0.0"
       }
     },
+    "global-npm": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/global-npm/-/global-npm-0.4.1.tgz",
+      "integrity": "sha512-/XasD4hg2kbBfxxLjCaqa4acGeaO4WshW7Mo7CCfZLgpHH3Jpdl0OKxhgob/8s842Sd9VrU7+E6ph65Yzn5wmQ==",
+      "requires": {
+        "which": "^2.0.2"
+      }
+    },
     "global-prefix": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-1.0.2.tgz",
@@ -838,65 +1134,78 @@
         "ini": "^1.3.4",
         "is-windows": "^1.0.1",
         "which": "^1.2.14"
+      },
+      "dependencies": {
+        "which": {
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+          "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+          "requires": {
+            "isexe": "^2.0.0"
+          }
+        }
       }
     },
     "graceful-fs": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
-      "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw=="
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.8.tgz",
+      "integrity": "sha512-qkIilPUYcNhJpd33n0GBXTB1MMPp14TxEsEs0pTrsSVucApsYzW5V+Q8Qxhik6KU3evy+qkAAowTByymK0avdg=="
     },
     "grunt": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/grunt/-/grunt-1.1.0.tgz",
-      "integrity": "sha512-+NGod0grmviZ7Nzdi9am7vuRS/h76PcWDsV635mEXF0PEQMUV6Kb+OjTdsVxbi0PZmfQOjCMKb3w8CVZcqsn1g==",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/grunt/-/grunt-1.4.1.tgz",
+      "integrity": "sha512-ZXIYXTsAVrA7sM+jZxjQdrBOAg7DyMUplOMhTaspMRExei+fD0BTwdWXnn0W5SXqhb/Q/nlkzXclSi3IH55PIA==",
       "requires": {
-        "coffeescript": "~1.10.0",
-        "dateformat": "~1.0.12",
+        "dateformat": "~3.0.3",
         "eventemitter2": "~0.4.13",
-        "exit": "~0.1.1",
+        "exit": "~0.1.2",
         "findup-sync": "~0.3.0",
-        "glob": "~7.0.0",
-        "grunt-cli": "~1.2.0",
-        "grunt-known-options": "~1.1.0",
-        "grunt-legacy-log": "~2.0.0",
-        "grunt-legacy-util": "~1.1.1",
+        "glob": "~7.1.6",
+        "grunt-cli": "~1.4.2",
+        "grunt-known-options": "~2.0.0",
+        "grunt-legacy-log": "~3.0.0",
+        "grunt-legacy-util": "~2.0.1",
         "iconv-lite": "~0.4.13",
-        "js-yaml": "~3.13.1",
-        "minimatch": "~3.0.2",
-        "mkdirp": "~1.0.3",
+        "js-yaml": "~3.14.0",
+        "minimatch": "~3.0.4",
+        "mkdirp": "~1.0.4",
         "nopt": "~3.0.6",
-        "path-is-absolute": "~1.0.0",
-        "rimraf": "~2.6.2"
+        "rimraf": "~3.0.2"
       },
       "dependencies": {
-        "grunt-cli": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/grunt-cli/-/grunt-cli-1.2.0.tgz",
-          "integrity": "sha1-VisRnrsGndtGSs4oRVAb6Xs1tqg=",
+        "glob": {
+          "version": "7.1.7",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz",
+          "integrity": "sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==",
           "requires": {
-            "findup-sync": "~0.3.0",
-            "grunt-known-options": "~1.1.0",
-            "nopt": "~3.0.6",
-            "resolve": "~1.1.0"
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         },
-        "resolve": {
-          "version": "1.1.7",
-          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
-          "integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs="
+        "rimraf": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+          "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+          "requires": {
+            "glob": "^7.1.3"
+          }
         }
       }
     },
     "grunt-cli": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/grunt-cli/-/grunt-cli-1.3.2.tgz",
-      "integrity": "sha512-8OHDiZZkcptxVXtMfDxJvmN7MVJNE8L/yIcPb4HB7TlyFD1kDvjHrb62uhySsU14wJx9ORMnTuhRMQ40lH/orQ==",
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/grunt-cli/-/grunt-cli-1.4.3.tgz",
+      "integrity": "sha512-9Dtx/AhVeB4LYzsViCjUQkd0Kw0McN2gYpdmGYKtE2a5Yt7v1Q+HYZVWhqXc/kGnxlMtqKDxSwotiGeFmkrCoQ==",
       "requires": {
-        "grunt-known-options": "~1.1.0",
+        "grunt-known-options": "~2.0.0",
         "interpret": "~1.1.0",
-        "liftoff": "~2.5.0",
+        "liftup": "~3.0.1",
         "nopt": "~4.0.1",
-        "v8flags": "~3.1.1"
+        "v8flags": "~3.2.0"
       },
       "dependencies": {
         "nopt": {
@@ -920,14 +1229,6 @@
         "maxmin": "^3.0.0"
       },
       "dependencies": {
-        "ansi-styles": {
-          "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-          "requires": {
-            "color-convert": "^2.0.1"
-          }
-        },
         "chalk": {
           "version": "4.1.2",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -936,19 +1237,6 @@
             "ansi-styles": "^4.1.0",
             "supports-color": "^7.1.0"
           }
-        },
-        "color-convert": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-          "requires": {
-            "color-name": "~1.1.4"
-          }
-        },
-        "color-name": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
         },
         "has-flag": {
           "version": "4.0.0",
@@ -966,63 +1254,66 @@
       }
     },
     "grunt-known-options": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/grunt-known-options/-/grunt-known-options-1.1.1.tgz",
-      "integrity": "sha512-cHwsLqoighpu7TuYj5RonnEuxGVFnztcUqTqp5rXFGYL4OuPFofwC4Ycg7n9fYwvK6F5WbYgeVOwph9Crs2fsQ=="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/grunt-known-options/-/grunt-known-options-2.0.0.tgz",
+      "integrity": "sha512-GD7cTz0I4SAede1/+pAbmJRG44zFLPipVtdL9o3vqx9IEyb7b4/Y3s7r6ofI3CchR5GvYJ+8buCSioDv5dQLiA=="
     },
     "grunt-legacy-log": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/grunt-legacy-log/-/grunt-legacy-log-2.0.0.tgz",
-      "integrity": "sha512-1m3+5QvDYfR1ltr8hjiaiNjddxGdQWcH0rw1iKKiQnF0+xtgTazirSTGu68RchPyh1OBng1bBUjLmX8q9NpoCw==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/grunt-legacy-log/-/grunt-legacy-log-3.0.0.tgz",
+      "integrity": "sha512-GHZQzZmhyq0u3hr7aHW4qUH0xDzwp2YXldLPZTCjlOeGscAOWWPftZG3XioW8MasGp+OBRIu39LFx14SLjXRcA==",
       "requires": {
         "colors": "~1.1.2",
-        "grunt-legacy-log-utils": "~2.0.0",
+        "grunt-legacy-log-utils": "~2.1.0",
         "hooker": "~0.2.3",
-        "lodash": "~4.17.5"
-      },
-      "dependencies": {
-        "lodash": {
-          "version": "4.17.15",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
-        }
+        "lodash": "~4.17.19"
       }
     },
     "grunt-legacy-log-utils": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/grunt-legacy-log-utils/-/grunt-legacy-log-utils-2.0.1.tgz",
-      "integrity": "sha512-o7uHyO/J+i2tXG8r2bZNlVk20vlIFJ9IEYyHMCQGfWYru8Jv3wTqKZzvV30YW9rWEjq0eP3cflQ1qWojIe9VFA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/grunt-legacy-log-utils/-/grunt-legacy-log-utils-2.1.0.tgz",
+      "integrity": "sha512-lwquaPXJtKQk0rUM1IQAop5noEpwFqOXasVoedLeNzaibf/OPWjKYvvdqnEHNmU+0T0CaReAXIbGo747ZD+Aaw==",
       "requires": {
-        "chalk": "~2.4.1",
-        "lodash": "~4.17.10"
+        "chalk": "~4.1.0",
+        "lodash": "~4.17.19"
       },
       "dependencies": {
-        "lodash": {
-          "version": "4.17.15",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
         }
       }
     },
     "grunt-legacy-util": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/grunt-legacy-util/-/grunt-legacy-util-1.1.1.tgz",
-      "integrity": "sha512-9zyA29w/fBe6BIfjGENndwoe1Uy31BIXxTH3s8mga0Z5Bz2Sp4UCjkeyv2tI449ymkx3x26B+46FV4fXEddl5A==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/grunt-legacy-util/-/grunt-legacy-util-2.0.1.tgz",
+      "integrity": "sha512-2bQiD4fzXqX8rhNdXkAywCadeqiPiay0oQny77wA2F3WF4grPJXCvAcyoWUJV+po/b15glGkxuSiQCK299UC2w==",
       "requires": {
-        "async": "~1.5.2",
-        "exit": "~0.1.1",
-        "getobject": "~0.1.0",
+        "async": "~3.2.0",
+        "exit": "~0.1.2",
+        "getobject": "~1.0.0",
         "hooker": "~0.2.3",
-        "lodash": "~4.17.10",
-        "underscore.string": "~3.3.4",
-        "which": "~1.3.0"
-      },
-      "dependencies": {
-        "lodash": {
-          "version": "4.17.15",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
-        }
+        "lodash": "~4.17.21",
+        "underscore.string": "~3.3.5",
+        "which": "~2.0.2"
       }
     },
     "gzip-size": {
@@ -1032,48 +1323,34 @@
       "requires": {
         "duplexer": "^0.1.1",
         "pify": "^4.0.1"
-      },
-      "dependencies": {
-        "pify": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
-          "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g=="
-        }
+      }
+    },
+    "har-schema": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
+      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
+    },
+    "har-validator": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.5.tgz",
+      "integrity": "sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==",
+      "requires": {
+        "ajv": "^6.12.3",
+        "har-schema": "^2.0.0"
+      }
+    },
+    "has": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+      "requires": {
+        "function-bind": "^1.1.1"
       }
     },
     "has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
       "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
-    },
-    "has-value": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
-      "integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
-      "requires": {
-        "get-value": "^2.0.6",
-        "has-values": "^1.0.0",
-        "isobject": "^3.0.0"
-      }
-    },
-    "has-values": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/has-values/-/has-values-1.0.0.tgz",
-      "integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
-      "requires": {
-        "is-number": "^3.0.0",
-        "kind-of": "^4.0.0"
-      },
-      "dependencies": {
-        "kind-of": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
-          "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
-          "requires": {
-            "is-buffer": "^1.1.5"
-          }
-        }
-      }
     },
     "highlight.js": {
       "version": "9.8.0",
@@ -1088,15 +1365,137 @@
         "parse-passwd": "^1.0.0"
       }
     },
+    "honkit": {
+      "version": "3.6.23",
+      "resolved": "https://registry.npmjs.org/honkit/-/honkit-3.6.23.tgz",
+      "integrity": "sha512-p+s9TXVBEYViEF6TlBqBS7Qx7McW+/MwKkzpnv7kuN6K58Ofdn8gQZdopXwqOGSE4i6ri55XjLj9+H8hrQLY5Q==",
+      "requires": {
+        "@honkit/asciidoc": "^3.6.17",
+        "@honkit/honkit-plugin-highlight": "^3.6.19",
+        "@honkit/honkit-plugin-theme-default": "^3.6.20",
+        "@honkit/markdown-legacy": "^3.6.17",
+        "bash-color": "^0.0.4",
+        "cheerio": "^0.20.0",
+        "chokidar": "^3.3.0",
+        "commander": "^5.1.0",
+        "cp": "^0.2.0",
+        "cpr": "^3.0.1",
+        "crc": "^3.8.0",
+        "destroy": "^1.0.4",
+        "direction": "^0.1.5",
+        "dom-serializer": "^0.1.0",
+        "error": "7.0.2",
+        "escape-html": "^1.0.3",
+        "escape-string-regexp": "^4.0.0",
+        "extend": "^3.0.0",
+        "flat-cache": "^2.0.1",
+        "front-matter": "^2.1.0",
+        "gitbook-plugin-fontsettings": "^2.0.0",
+        "gitbook-plugin-livereload": "^0.0.1",
+        "gitbook-plugin-lunr": "^1.2.0",
+        "gitbook-plugin-search": "^2.2.1",
+        "github-slugid": "^1.0.1",
+        "global-npm": "^0.4.0",
+        "i18n-t": "^1.0.1",
+        "ignore": "^5.1.8",
+        "immutable": "^3.8.1",
+        "is": "^3.1.0",
+        "js-yaml": "^3.6.1",
+        "json-schema-defaults": "^0.1.1",
+        "jsonschema": "1.1.0",
+        "juice": "^6.0.0",
+        "memoize-one": "^5.1.1",
+        "mkdirp": "^1.0.4",
+        "moment": "^2.24.0",
+        "nunjucks": "^3.2.0",
+        "nunjucks-do": "^1.0.0",
+        "object-path": "^0.11.5",
+        "omit-keys": "^0.1.0",
+        "open": "^7.0.0",
+        "q": "^1.5.1",
+        "read-installed": "^4.0.3",
+        "request": "^2.88.0",
+        "resolve": "^1.17.0",
+        "semver": "^5.1.0",
+        "send": "^0.17.1",
+        "tiny-lr": "^1.1.1",
+        "tmp": "0.0.28",
+        "try-resolve": "^1.0.1",
+        "urijs": "^1.19.6"
+      },
+      "dependencies": {
+        "cheerio": {
+          "version": "0.20.0",
+          "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-0.20.0.tgz",
+          "integrity": "sha1-XHEPK6uVZTJyhCugHG6mGzVF7DU=",
+          "requires": {
+            "css-select": "~1.2.0",
+            "dom-serializer": "~0.1.0",
+            "entities": "~1.1.1",
+            "htmlparser2": "~3.8.1",
+            "jsdom": "^7.0.2",
+            "lodash": "^4.1.0"
+          }
+        },
+        "domhandler": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.3.0.tgz",
+          "integrity": "sha1-LeWaCCLVAn+r/28DLCsloqir5zg=",
+          "requires": {
+            "domelementtype": "1"
+          }
+        },
+        "htmlparser2": {
+          "version": "3.8.3",
+          "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.8.3.tgz",
+          "integrity": "sha1-mWwosZFRaovoZQGn15dX5ccMEGg=",
+          "requires": {
+            "domelementtype": "1",
+            "domhandler": "2.3",
+            "domutils": "1.5",
+            "entities": "1.0",
+            "readable-stream": "1.1"
+          },
+          "dependencies": {
+            "entities": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/entities/-/entities-1.0.0.tgz",
+              "integrity": "sha1-sph6o4ITR/zeZCsk/fyeT7cSvyY="
+            }
+          }
+        },
+        "readable-stream": {
+          "version": "1.1.14",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+          "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
+            "isarray": "0.0.1",
+            "string_decoder": "~0.10.x"
+          }
+        },
+        "string_decoder": {
+          "version": "0.10.31",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+        }
+      }
+    },
     "hooker": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/hooker/-/hooker-0.2.3.tgz",
       "integrity": "sha1-uDT3I8xKJCqmWWNFnfbZhMXT2Vk="
     },
     "hosted-git-info": {
-      "version": "2.8.8",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.8.tgz",
-      "integrity": "sha512-f/wzC2QaWBs7t9IYqB4T3sR1xviIViXJRJTWBlx2Gf3g0Xi5vI7Yy4koXQ1c9OYDGHN9sBy1DQ2AB8fqZBWhUg=="
+      "version": "2.8.9",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
+      "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw=="
+    },
+    "html-entities": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-1.2.0.tgz",
+      "integrity": "sha1-QZSMr4XOgv7Tbk5qDtNxpmZDeeI="
     },
     "htmlparser2": {
       "version": "3.10.1",
@@ -1111,6 +1510,41 @@
         "readable-stream": "^3.1.1"
       }
     },
+    "http-errors": {
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.7.3.tgz",
+      "integrity": "sha512-ZTTX0MWrsQ2ZAhA1cejAwDLycFsd7I7nVtnkT3Ol0aqodaKW+0CTZDQ1uBv5whptCnc8e8HeRRJxRs0kmm/Qfw==",
+      "requires": {
+        "depd": "~1.1.2",
+        "inherits": "2.0.4",
+        "setprototypeof": "1.1.1",
+        "statuses": ">= 1.5.0 < 2",
+        "toidentifier": "1.0.0"
+      }
+    },
+    "http-parser-js": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.5.3.tgz",
+      "integrity": "sha512-t7hjvef/5HEK7RWTdUzVUhl8zkEu+LlaE0IYzdMuvbSDipxBRpOn4Uhw8ZyECEa808iVT8XCjzo6xmYt4CiLZg=="
+    },
+    "http-signature": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+      "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+      "requires": {
+        "assert-plus": "^1.0.0",
+        "jsprim": "^1.2.2",
+        "sshpk": "^1.7.0"
+      }
+    },
+    "i18n-t": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/i18n-t/-/i18n-t-1.0.1.tgz",
+      "integrity": "sha1-t79LAD45XcdHhD6Pyl3kd2WLCxw=",
+      "requires": {
+        "lodash": "^4.13.1"
+      }
+    },
     "iconv-lite": {
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
@@ -1119,13 +1553,25 @@
         "safer-buffer": ">= 2.1.2 < 3"
       }
     },
-    "indent-string": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
-      "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
-      "requires": {
-        "repeating": "^2.0.0"
-      }
+    "ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="
+    },
+    "ignore": {
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.9.tgz",
+      "integrity": "sha512-2zeMQpbKz5dhZ9IwL0gbxSW5w0NK/MSAMtNuhgIHEPmaU3vPdKPL0UdvUCXs5SS4JAwsBxysK5sFMW8ocFiVjQ=="
+    },
+    "image-size": {
+      "version": "0.7.5",
+      "resolved": "https://registry.npmjs.org/image-size/-/image-size-0.7.5.tgz",
+      "integrity": "sha512-Hiyv+mXHfFEP7LzUL/llg9RwFxxY+o9N3JVLIeG5E7iFIFAalxvRU9UZthBdYDEVnzHMgjnKJPPpay5BWf1g9g=="
+    },
+    "immutable": {
+      "version": "3.8.2",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-3.8.2.tgz",
+      "integrity": "sha1-wkOZUUVbs5kT2vKBN28VMOEErfM="
     },
     "inflight": {
       "version": "1.0.6",
@@ -1142,14 +1588,19 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "ini": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
-      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="
     },
     "interpret": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.1.0.tgz",
       "integrity": "sha1-ftGxQQxqDg94z5XTuEQMY/eLhhQ="
+    },
+    "is": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/is/-/is-3.3.0.tgz",
+      "integrity": "sha512-nW24QBoPcFGGHJGUwnfpI7Yc5CdqWNdsyHQszVE/z2pKHXzh7FZ5GWhJqSyaQ9wMkQnsTx+kAI8bHlCX4tKdbg=="
     },
     "is-absolute": {
       "version": "1.0.0",
@@ -1160,109 +1611,49 @@
         "is-windows": "^1.0.1"
       }
     },
-    "is-accessor-descriptor": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
-      "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+    "is-binary-path": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
       "requires": {
-        "kind-of": "^3.0.2"
-      },
-      "dependencies": {
-        "kind-of": {
-          "version": "3.2.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-          "requires": {
-            "is-buffer": "^1.1.5"
-          }
-        }
+        "binary-extensions": "^2.0.0"
       }
     },
-    "is-arrayish": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0="
-    },
-    "is-buffer": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
-    },
-    "is-data-descriptor": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
-      "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+    "is-core-module": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.8.0.tgz",
+      "integrity": "sha512-vd15qHsaqrRL7dtH6QNuy0ndJmRDrS9HAM1CAiSifNUFv4x1a0CCVsj18hJ1mShxIG6T2i1sO78MkP56r0nYRw==",
       "requires": {
-        "kind-of": "^3.0.2"
-      },
-      "dependencies": {
-        "kind-of": {
-          "version": "3.2.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-          "requires": {
-            "is-buffer": "^1.1.5"
-          }
-        }
+        "has": "^1.0.3"
       }
     },
-    "is-descriptor": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
-      "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
-      "requires": {
-        "is-accessor-descriptor": "^0.1.6",
-        "is-data-descriptor": "^0.1.4",
-        "kind-of": "^5.0.0"
-      },
-      "dependencies": {
-        "kind-of": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-          "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw=="
-        }
-      }
-    },
-    "is-extendable": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
-      "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik="
+    "is-docker": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
+      "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ=="
     },
     "is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI="
     },
-    "is-finite": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.1.0.tgz",
-      "integrity": "sha512-cdyMtqX/BOqqNBBiKlIVkytNHm49MtMlYyn1zxzvJKWmFMlGzm+ry5BBfYyeY9YmNKbRSo/o7OX9w9ale0wg3w=="
+    "is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
     },
     "is-glob": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
-      "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
       "requires": {
-        "is-extglob": "^2.1.0"
+        "is-extglob": "^2.1.1"
       }
     },
     "is-number": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
-      "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
-      "requires": {
-        "kind-of": "^3.0.2"
-      },
-      "dependencies": {
-        "kind-of": {
-          "version": "3.2.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-          "requires": {
-            "is-buffer": "^1.1.5"
-          }
-        }
-      }
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="
     },
     "is-plain-object": {
       "version": "2.0.4",
@@ -1270,6 +1661,13 @@
       "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
       "requires": {
         "isobject": "^3.0.1"
+      },
+      "dependencies": {
+        "isobject": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+        }
       }
     },
     "is-relative": {
@@ -1280,6 +1678,11 @@
         "is-unc-path": "^1.0.0"
       }
     },
+    "is-typedarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
+    },
     "is-unc-path": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-unc-path/-/is-unc-path-1.0.0.tgz",
@@ -1288,20 +1691,23 @@
         "unc-path-regex": "^0.1.2"
       }
     },
-    "is-utf8": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
-      "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI="
-    },
     "is-windows": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
       "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA=="
     },
+    "is-wsl": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
+      "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
+      "requires": {
+        "is-docker": "^2.0.0"
+      }
+    },
     "isarray": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+      "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
     },
     "isexe": {
       "version": "2.0.0",
@@ -1309,25 +1715,112 @@
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
     },
     "isobject": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-      "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/isobject/-/isobject-0.2.0.tgz",
+      "integrity": "sha1-o0MhkvObkQtfAsyYlIeDbscKqF4="
+    },
+    "isstream": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
     },
     "js-yaml": {
-      "version": "3.13.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
-      "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
+      "version": "3.14.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
       "requires": {
         "argparse": "^1.0.7",
         "esprima": "^4.0.0"
       }
     },
-    "jsonfile": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-3.0.1.tgz",
-      "integrity": "sha1-pezG9l9T9mLEQVx2daAzHQmS7GY=",
+    "jsbn": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM="
+    },
+    "jsdom": {
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-7.2.2.tgz",
+      "integrity": "sha1-QLQCdwwr2iNGkJa+6Rq2deOx/G4=",
+      "optional": true,
       "requires": {
-        "graceful-fs": "^4.1.6"
+        "abab": "^1.0.0",
+        "acorn": "^2.4.0",
+        "acorn-globals": "^1.0.4",
+        "cssom": ">= 0.3.0 < 0.4.0",
+        "cssstyle": ">= 0.2.29 < 0.3.0",
+        "escodegen": "^1.6.1",
+        "nwmatcher": ">= 1.3.7 < 2.0.0",
+        "parse5": "^1.5.1",
+        "request": "^2.55.0",
+        "sax": "^1.1.4",
+        "symbol-tree": ">= 3.1.0 < 4.0.0",
+        "tough-cookie": "^2.2.0",
+        "webidl-conversions": "^2.0.0",
+        "whatwg-url-compat": "~0.6.5",
+        "xml-name-validator": ">= 2.0.1 < 3.0.0"
+      }
+    },
+    "json-parse-even-better-errors": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w=="
+    },
+    "json-schema": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
+    },
+    "json-schema-defaults": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/json-schema-defaults/-/json-schema-defaults-0.1.1.tgz",
+      "integrity": "sha1-HGxhA8Q0m3G29Ko4LD3ZqhyLraM="
+    },
+    "json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
+    },
+    "json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
+    },
+    "jsonschema": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/jsonschema/-/jsonschema-1.1.0.tgz",
+      "integrity": "sha1-A5zCGe1SSwbnHa8SymDQJjn68po="
+    },
+    "jsprim": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
+      "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+      "requires": {
+        "assert-plus": "1.0.0",
+        "extsprintf": "1.3.0",
+        "json-schema": "0.2.3",
+        "verror": "1.10.0"
+      }
+    },
+    "juice": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/juice/-/juice-6.0.0.tgz",
+      "integrity": "sha512-5T3JPgXYiw6A6axsb9E09Gzq46WbfJeDirY6nMrqY55iAdqEoPDxSr1GpXqYfoyndx4ujpBPXGLzBRzbiqOOaw==",
+      "requires": {
+        "cheerio": "^0.22.0",
+        "commander": "^2.15.1",
+        "cross-spawn": "^6.0.5",
+        "deep-extend": "^0.6.0",
+        "mensch": "^0.3.4",
+        "slick": "^1.12.2",
+        "web-resource-inliner": "^4.3.3"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "2.20.3",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+          "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
+        }
       }
     },
     "kind-of": {
@@ -1335,50 +1828,66 @@
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
       "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw=="
     },
-    "liftoff": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/liftoff/-/liftoff-2.5.0.tgz",
-      "integrity": "sha1-IAkpG7Mc6oYbvxCnwVooyvdcMew=",
+    "kramed": {
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/kramed/-/kramed-0.5.6.tgz",
+      "integrity": "sha1-XDeXm8u1nLt6jSMQSUCSmIV7UWI="
+    },
+    "levn": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
+      "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+      "optional": true,
       "requires": {
-        "extend": "^3.0.0",
-        "findup-sync": "^2.0.0",
-        "fined": "^1.0.1",
-        "flagged-respawn": "^1.0.0",
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2"
+      }
+    },
+    "liftup": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/liftup/-/liftup-3.0.1.tgz",
+      "integrity": "sha512-yRHaiQDizWSzoXk3APcA71eOI/UuhEkNN9DiW2Tt44mhYzX4joFoCZlxsSOF7RyeLlfqzFLQI1ngFq3ggMPhOw==",
+      "requires": {
+        "extend": "^3.0.2",
+        "findup-sync": "^4.0.0",
+        "fined": "^1.2.0",
+        "flagged-respawn": "^1.0.1",
         "is-plain-object": "^2.0.4",
-        "object.map": "^1.0.0",
-        "rechoir": "^0.6.2",
-        "resolve": "^1.1.7"
+        "object.map": "^1.0.1",
+        "rechoir": "^0.7.0",
+        "resolve": "^1.19.0"
       },
       "dependencies": {
         "findup-sync": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-2.0.0.tgz",
-          "integrity": "sha1-kyaxSIwi0aYIhlCoaQGy2akKLLw=",
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-4.0.0.tgz",
+          "integrity": "sha512-6jvvn/12IC4quLBL1KNokxC7wWTvYncaVUYSoxWw7YykPLuRrnv4qdHcSOywOI5RpkOVGeQRtWM8/q+G6W6qfQ==",
           "requires": {
             "detect-file": "^1.0.0",
-            "is-glob": "^3.1.0",
-            "micromatch": "^3.0.4",
+            "is-glob": "^4.0.0",
+            "micromatch": "^4.0.2",
             "resolve-dir": "^1.0.1"
           }
         }
       }
     },
-    "load-json-file": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
-      "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
+    "livereload-js": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/livereload-js/-/livereload-js-2.4.0.tgz",
+      "integrity": "sha512-XPQH8Z2GDP/Hwz2PCDrh2mth4yFejwA1OZ/81Ti3LgKyhDcEjsSsqFWZojHG0va/duGd+WyosY7eXLDoOyqcPw=="
+    },
+    "locate-path": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
       "requires": {
-        "graceful-fs": "^4.1.2",
-        "parse-json": "^2.2.0",
-        "pify": "^2.0.0",
-        "pinkie-promise": "^2.0.0",
-        "strip-bom": "^2.0.0"
+        "p-locate": "^4.1.0"
       }
     },
     "lodash": {
-      "version": "4.17.4",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-      "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "lodash.assignin": {
       "version": "4.2.0",
@@ -1440,14 +1949,15 @@
       "resolved": "https://registry.npmjs.org/lodash.some/-/lodash.some-4.6.0.tgz",
       "integrity": "sha1-G7nzFO9ri63tE7VJFpsqlF62jk0="
     },
-    "loud-rejection": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
-      "integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
-      "requires": {
-        "currently-unhandled": "^0.4.1",
-        "signal-exit": "^3.0.0"
-      }
+    "lodash.unescape": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.unescape/-/lodash.unescape-4.0.1.tgz",
+      "integrity": "sha1-vyJJiGzlFM2hEvrpIYzcBlIR/Jw="
+    },
+    "lunr": {
+      "version": "0.5.12",
+      "resolved": "https://registry.npmjs.org/lunr/-/lunr-0.5.12.tgz",
+      "integrity": "sha1-ova314AcvizLFpbaZ/H3eI+J4Mg="
     },
     "make-iterator": {
       "version": "1.0.1",
@@ -1462,19 +1972,6 @@
       "resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
       "integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8="
     },
-    "map-obj": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
-      "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0="
-    },
-    "map-visit": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
-      "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
-      "requires": {
-        "object-visit": "^1.0.0"
-      }
-    },
     "maxmin": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/maxmin/-/maxmin-3.0.0.tgz",
@@ -1486,14 +1983,6 @@
         "pretty-bytes": "^5.3.0"
       },
       "dependencies": {
-        "ansi-styles": {
-          "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-          "requires": {
-            "color-convert": "^2.0.1"
-          }
-        },
         "chalk": {
           "version": "4.1.2",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -1502,19 +1991,6 @@
             "ansi-styles": "^4.1.0",
             "supports-color": "^7.1.0"
           }
-        },
-        "color-convert": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-          "requires": {
-            "color-name": "~1.1.4"
-          }
-        },
-        "color-name": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
         },
         "has-flag": {
           "version": "4.0.0",
@@ -1531,49 +2007,47 @@
         }
       }
     },
-    "meow": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
-      "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
-      "requires": {
-        "camelcase-keys": "^2.0.0",
-        "decamelize": "^1.1.2",
-        "loud-rejection": "^1.0.0",
-        "map-obj": "^1.0.1",
-        "minimist": "^1.1.3",
-        "normalize-package-data": "^2.3.4",
-        "object-assign": "^4.0.1",
-        "read-pkg-up": "^1.0.1",
-        "redent": "^1.0.0",
-        "trim-newlines": "^1.0.0"
-      },
-      "dependencies": {
-        "minimist": {
-          "version": "1.2.5",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
-        }
-      }
+    "memoize-one": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.2.1.tgz",
+      "integrity": "sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q=="
+    },
+    "mensch": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/mensch/-/mensch-0.3.4.tgz",
+      "integrity": "sha512-IAeFvcOnV9V0Yk+bFhYR07O3yNina9ANIN5MoXBKYJ/RLYPurd2d0yw14MDhpr9/momp0WofT1bPUh3hkzdi/g=="
     },
     "micromatch": {
-      "version": "3.1.10",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
-      "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.4.tgz",
+      "integrity": "sha512-pRmzw/XUcwXGpD9aI9q/0XOwLNygjETJ8y0ao0wdqprrzDa4YnxLcz7fQRZr8voh8V10kGhABbNcHVk5wHgWwg==",
       "requires": {
-        "arr-diff": "^4.0.0",
-        "array-unique": "^0.3.2",
-        "braces": "^2.3.1",
-        "define-property": "^2.0.2",
-        "extend-shallow": "^3.0.2",
-        "extglob": "^2.0.4",
-        "fragment-cache": "^0.2.1",
-        "kind-of": "^6.0.2",
-        "nanomatch": "^1.2.9",
-        "object.pick": "^1.3.0",
-        "regex-not": "^1.0.0",
-        "snapdragon": "^0.8.1",
-        "to-regex": "^3.0.2"
+        "braces": "^3.0.1",
+        "picomatch": "^2.2.3"
       }
+    },
+    "mime": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg=="
+    },
+    "mime-db": {
+      "version": "1.51.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.51.0.tgz",
+      "integrity": "sha512-5y8A56jg7XVQx2mbv1lu49NR4dokRnhZYTtL+KGfaa27uq4pSTXkwQkFJl4pkRMyNFz/EtYDSkiiEHx3F7UN6g=="
+    },
+    "mime-types": {
+      "version": "2.1.34",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.34.tgz",
+      "integrity": "sha512-6cP692WwGIs9XXdOO4++N+7qjqv0rqxxVvJ3VHPh/Sc9mVZcQP+ZGhkKiTvWMQRr2tbHkJP/Yn7Y0npb3ZBs4A==",
+      "requires": {
+        "mime-db": "1.51.0"
+      }
+    },
+    "mimer": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/mimer/-/mimer-1.1.1.tgz",
+      "integrity": "sha512-ye7CWOnSgiX3mqOLJ0bNGxRAULS5a/gzjj6lGSCnRTkbLUhNvt/7dI80b6GZRoaj4CsylcWQzyyKKh1a3CT74g=="
     },
     "minimatch": {
       "version": "3.0.4",
@@ -1584,56 +2058,29 @@
       }
     },
     "minimist": {
-      "version": "0.0.10",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
-      "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8="
-    },
-    "mixin-deep": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.2.tgz",
-      "integrity": "sha512-WRoDn//mXBiJ1H40rqa3vH0toePwSsGb45iInWlTySa+Uu4k3tYUSxa2v1KqAiLtvlrSzaExqS1gtk96A9zvEA==",
-      "requires": {
-        "for-in": "^1.0.2",
-        "is-extendable": "^1.0.1"
-      },
-      "dependencies": {
-        "is-extendable": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
-          "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
-          "requires": {
-            "is-plain-object": "^2.0.4"
-          }
-        }
-      }
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
     },
     "mkdirp": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
       "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw=="
     },
-    "ms": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+    "moment": {
+      "version": "2.29.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.1.tgz",
+      "integrity": "sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ=="
     },
-    "nanomatch": {
-      "version": "1.2.13",
-      "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz",
-      "integrity": "sha512-fpoe2T0RbHwBTBUOftAfBPaDEi06ufaUai0mE6Yn1kacc3SnTErfb/h+X94VXzI64rKFHYImXSvdwGGCmwOqCA==",
-      "requires": {
-        "arr-diff": "^4.0.0",
-        "array-unique": "^0.3.2",
-        "define-property": "^2.0.2",
-        "extend-shallow": "^3.0.2",
-        "fragment-cache": "^0.2.1",
-        "is-windows": "^1.0.2",
-        "kind-of": "^6.0.2",
-        "object.pick": "^1.3.0",
-        "regex-not": "^1.0.0",
-        "snapdragon": "^0.8.1",
-        "to-regex": "^3.0.1"
-      }
+    "ms": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+      "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
+    },
+    "nice-try": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
+      "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ=="
     },
     "nopt": {
       "version": "3.0.6",
@@ -1654,4021 +2101,15 @@
         "validate-npm-package-license": "^3.0.1"
       }
     },
-    "npm": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/npm/-/npm-5.1.0.tgz",
-      "integrity": "sha512-pt5ClxEmY/dLpb60SmGQQBKi3nB6Ljx1FXmpoCUdAULlGqGVn2uCyXxPCWFbcuHGthT7qGiaGa1wOfs/UjGYMw==",
-      "requires": {
-        "JSONStream": "~1.3.1",
-        "abbrev": "~1.1.0",
-        "ansi-regex": "~3.0.0",
-        "ansicolors": "~0.3.2",
-        "ansistyles": "~0.1.3",
-        "aproba": "~1.1.2",
-        "archy": "~1.0.0",
-        "bluebird": "~3.5.0",
-        "cacache": "~9.2.9",
-        "call-limit": "~1.1.0",
-        "chownr": "~1.0.1",
-        "cmd-shim": "~2.0.2",
-        "columnify": "~1.5.4",
-        "config-chain": "~1.1.11",
-        "debuglog": "*",
-        "detect-indent": "~5.0.0",
-        "dezalgo": "~1.0.3",
-        "editor": "~1.0.0",
-        "fs-vacuum": "~1.2.10",
-        "fs-write-stream-atomic": "~1.0.10",
-        "fstream": "~1.0.11",
-        "fstream-npm": "~1.2.1",
-        "glob": "~7.1.2",
-        "graceful-fs": "~4.1.11",
-        "has-unicode": "~2.0.1",
-        "hosted-git-info": "~2.5.0",
-        "iferr": "~0.1.5",
-        "imurmurhash": "*",
-        "inflight": "~1.0.6",
-        "inherits": "~2.0.3",
-        "ini": "~1.3.4",
-        "init-package-json": "~1.10.1",
-        "lazy-property": "~1.0.0",
-        "lockfile": "~1.0.3",
-        "lodash._baseindexof": "*",
-        "lodash._baseuniq": "~4.6.0",
-        "lodash._bindcallback": "*",
-        "lodash._cacheindexof": "*",
-        "lodash._createcache": "*",
-        "lodash._getnative": "*",
-        "lodash.clonedeep": "~4.5.0",
-        "lodash.restparam": "*",
-        "lodash.union": "~4.6.0",
-        "lodash.uniq": "~4.5.0",
-        "lodash.without": "~4.4.0",
-        "lru-cache": "~4.1.1",
-        "mississippi": "~1.3.0",
-        "mkdirp": "~0.5.1",
-        "move-concurrently": "~1.0.1",
-        "node-gyp": "~3.6.2",
-        "nopt": "~4.0.1",
-        "normalize-package-data": "~2.4.0",
-        "npm-cache-filename": "~1.0.2",
-        "npm-install-checks": "~3.0.0",
-        "npm-package-arg": "~5.1.2",
-        "npm-registry-client": "~8.4.0",
-        "npm-user-validate": "~1.0.0",
-        "npmlog": "~4.1.2",
-        "once": "~1.4.0",
-        "opener": "~1.4.3",
-        "osenv": "~0.1.4",
-        "pacote": "~2.7.38",
-        "path-is-inside": "~1.0.2",
-        "promise-inflight": "~1.0.1",
-        "read": "~1.0.7",
-        "read-cmd-shim": "~1.0.1",
-        "read-installed": "~4.0.3",
-        "read-package-json": "~2.0.9",
-        "read-package-tree": "~5.1.6",
-        "readable-stream": "~2.3.2",
-        "readdir-scoped-modules": "*",
-        "request": "~2.81.0",
-        "retry": "~0.10.1",
-        "rimraf": "~2.6.1",
-        "safe-buffer": "~5.1.1",
-        "semver": "~5.3.0",
-        "sha": "~2.0.1",
-        "slide": "~1.1.6",
-        "sorted-object": "~2.0.1",
-        "sorted-union-stream": "~2.1.3",
-        "ssri": "~4.1.6",
-        "strip-ansi": "~4.0.0",
-        "tar": "~2.2.1",
-        "text-table": "~0.2.0",
-        "uid-number": "0.0.6",
-        "umask": "~1.1.0",
-        "unique-filename": "~1.1.0",
-        "unpipe": "~1.0.0",
-        "update-notifier": "~2.2.0",
-        "uuid": "~3.1.0",
-        "validate-npm-package-license": "*",
-        "validate-npm-package-name": "~3.0.0",
-        "which": "~1.2.14",
-        "worker-farm": "~1.3.1",
-        "wrappy": "~1.0.2",
-        "write-file-atomic": "~2.1.0"
-      },
-      "dependencies": {
-        "JSONStream": {
-          "version": "1.3.1",
-          "bundled": true,
-          "requires": {
-            "jsonparse": "^1.2.0",
-            "through": ">=2.2.7 <3"
-          },
-          "dependencies": {
-            "jsonparse": {
-              "version": "1.3.1",
-              "bundled": true
-            },
-            "through": {
-              "version": "2.3.8",
-              "bundled": true
-            }
-          }
-        },
-        "abbrev": {
-          "version": "1.1.0",
-          "bundled": true
-        },
-        "ansi-regex": {
-          "version": "3.0.0",
-          "bundled": true
-        },
-        "ansicolors": {
-          "version": "0.3.2",
-          "bundled": true
-        },
-        "ansistyles": {
-          "version": "0.1.3",
-          "bundled": true
-        },
-        "aproba": {
-          "version": "1.1.2",
-          "bundled": true
-        },
-        "archy": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "bluebird": {
-          "version": "3.5.0",
-          "bundled": true
-        },
-        "cacache": {
-          "version": "9.2.9",
-          "bundled": true,
-          "requires": {
-            "bluebird": "^3.5.0",
-            "chownr": "^1.0.1",
-            "glob": "^7.1.2",
-            "graceful-fs": "^4.1.11",
-            "lru-cache": "^4.1.1",
-            "mississippi": "^1.3.0",
-            "mkdirp": "^0.5.1",
-            "move-concurrently": "^1.0.1",
-            "promise-inflight": "^1.0.1",
-            "rimraf": "^2.6.1",
-            "ssri": "^4.1.6",
-            "unique-filename": "^1.1.0",
-            "y18n": "^3.2.1"
-          },
-          "dependencies": {
-            "lru-cache": {
-              "version": "4.1.1",
-              "bundled": true,
-              "requires": {
-                "pseudomap": "^1.0.2",
-                "yallist": "^2.1.2"
-              },
-              "dependencies": {
-                "pseudomap": {
-                  "version": "1.0.2",
-                  "bundled": true
-                },
-                "yallist": {
-                  "version": "2.1.2",
-                  "bundled": true
-                }
-              }
-            },
-            "y18n": {
-              "version": "3.2.1",
-              "bundled": true
-            }
-          }
-        },
-        "call-limit": {
-          "version": "1.1.0",
-          "bundled": true
-        },
-        "chownr": {
-          "version": "1.0.1",
-          "bundled": true
-        },
-        "cmd-shim": {
-          "version": "2.0.2",
-          "bundled": true,
-          "requires": {
-            "graceful-fs": "^4.1.2",
-            "mkdirp": "~0.5.0"
-          }
-        },
-        "columnify": {
-          "version": "1.5.4",
-          "bundled": true,
-          "requires": {
-            "strip-ansi": "^3.0.0",
-            "wcwidth": "^1.0.0"
-          },
-          "dependencies": {
-            "strip-ansi": {
-              "version": "3.0.1",
-              "bundled": true,
-              "requires": {
-                "ansi-regex": "^2.0.0"
-              },
-              "dependencies": {
-                "ansi-regex": {
-                  "version": "2.1.1",
-                  "bundled": true
-                }
-              }
-            },
-            "wcwidth": {
-              "version": "1.0.1",
-              "bundled": true,
-              "requires": {
-                "defaults": "^1.0.3"
-              },
-              "dependencies": {
-                "defaults": {
-                  "version": "1.0.3",
-                  "bundled": true,
-                  "requires": {
-                    "clone": "^1.0.2"
-                  },
-                  "dependencies": {
-                    "clone": {
-                      "version": "1.0.2",
-                      "bundled": true
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "config-chain": {
-          "version": "1.1.11",
-          "bundled": true,
-          "requires": {
-            "ini": "^1.3.4",
-            "proto-list": "~1.2.1"
-          },
-          "dependencies": {
-            "proto-list": {
-              "version": "1.2.4",
-              "bundled": true
-            }
-          }
-        },
-        "debuglog": {
-          "version": "1.0.1",
-          "bundled": true
-        },
-        "detect-indent": {
-          "version": "5.0.0",
-          "bundled": true
-        },
-        "dezalgo": {
-          "version": "1.0.3",
-          "bundled": true,
-          "requires": {
-            "asap": "^2.0.0",
-            "wrappy": "1"
-          },
-          "dependencies": {
-            "asap": {
-              "version": "2.0.5",
-              "bundled": true
-            }
-          }
-        },
-        "editor": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "fs-vacuum": {
-          "version": "1.2.10",
-          "bundled": true,
-          "requires": {
-            "graceful-fs": "^4.1.2",
-            "path-is-inside": "^1.0.1",
-            "rimraf": "^2.5.2"
-          }
-        },
-        "fs-write-stream-atomic": {
-          "version": "1.0.10",
-          "bundled": true,
-          "requires": {
-            "graceful-fs": "^4.1.2",
-            "iferr": "^0.1.5",
-            "imurmurhash": "^0.1.4",
-            "readable-stream": "1 || 2"
-          }
-        },
-        "fstream": {
-          "version": "1.0.11",
-          "bundled": true,
-          "requires": {
-            "graceful-fs": "^4.1.2",
-            "inherits": "~2.0.0",
-            "mkdirp": ">=0.5 0",
-            "rimraf": "2"
-          }
-        },
-        "fstream-npm": {
-          "version": "1.2.1",
-          "bundled": true,
-          "requires": {
-            "fstream-ignore": "^1.0.0",
-            "inherits": "2"
-          },
-          "dependencies": {
-            "fstream-ignore": {
-              "version": "1.0.5",
-              "bundled": true,
-              "requires": {
-                "fstream": "^1.0.0",
-                "inherits": "2",
-                "minimatch": "^3.0.0"
-              },
-              "dependencies": {
-                "minimatch": {
-                  "version": "3.0.4",
-                  "bundled": true,
-                  "requires": {
-                    "brace-expansion": "^1.1.7"
-                  },
-                  "dependencies": {
-                    "brace-expansion": {
-                      "version": "1.1.8",
-                      "bundled": true,
-                      "requires": {
-                        "balanced-match": "^1.0.0",
-                        "concat-map": "0.0.1"
-                      },
-                      "dependencies": {
-                        "balanced-match": {
-                          "version": "1.0.0",
-                          "bundled": true
-                        },
-                        "concat-map": {
-                          "version": "0.0.1",
-                          "bundled": true
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "glob": {
-          "version": "7.1.2",
-          "bundled": true,
-          "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
-          },
-          "dependencies": {
-            "fs.realpath": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "minimatch": {
-              "version": "3.0.4",
-              "bundled": true,
-              "requires": {
-                "brace-expansion": "^1.1.7"
-              },
-              "dependencies": {
-                "brace-expansion": {
-                  "version": "1.1.8",
-                  "bundled": true,
-                  "requires": {
-                    "balanced-match": "^1.0.0",
-                    "concat-map": "0.0.1"
-                  },
-                  "dependencies": {
-                    "balanced-match": {
-                      "version": "1.0.0",
-                      "bundled": true
-                    },
-                    "concat-map": {
-                      "version": "0.0.1",
-                      "bundled": true
-                    }
-                  }
-                }
-              }
-            },
-            "path-is-absolute": {
-              "version": "1.0.1",
-              "bundled": true
-            }
-          }
-        },
-        "graceful-fs": {
-          "version": "4.1.11",
-          "bundled": true
-        },
-        "has-unicode": {
-          "version": "2.0.1",
-          "bundled": true
-        },
-        "hosted-git-info": {
-          "version": "2.5.0",
-          "bundled": true
-        },
-        "iferr": {
-          "version": "0.1.5",
-          "bundled": true
-        },
-        "imurmurhash": {
-          "version": "0.1.4",
-          "bundled": true
-        },
-        "inflight": {
-          "version": "1.0.6",
-          "bundled": true,
-          "requires": {
-            "once": "^1.3.0",
-            "wrappy": "1"
-          }
-        },
-        "inherits": {
-          "version": "2.0.3",
-          "bundled": true
-        },
-        "ini": {
-          "version": "1.3.4",
-          "bundled": true
-        },
-        "init-package-json": {
-          "version": "1.10.1",
-          "bundled": true,
-          "requires": {
-            "glob": "^7.1.1",
-            "npm-package-arg": "^4.0.0 || ^5.0.0",
-            "promzard": "^0.3.0",
-            "read": "~1.0.1",
-            "read-package-json": "1 || 2",
-            "semver": "2.x || 3.x || 4 || 5",
-            "validate-npm-package-license": "^3.0.1",
-            "validate-npm-package-name": "^3.0.0"
-          },
-          "dependencies": {
-            "promzard": {
-              "version": "0.3.0",
-              "bundled": true,
-              "requires": {
-                "read": "1"
-              }
-            }
-          }
-        },
-        "lazy-property": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "lockfile": {
-          "version": "1.0.3",
-          "bundled": true
-        },
-        "lodash._baseindexof": {
-          "version": "3.1.0",
-          "bundled": true
-        },
-        "lodash._baseuniq": {
-          "version": "4.6.0",
-          "bundled": true,
-          "requires": {
-            "lodash._createset": "~4.0.0",
-            "lodash._root": "~3.0.0"
-          },
-          "dependencies": {
-            "lodash._createset": {
-              "version": "4.0.3",
-              "bundled": true
-            },
-            "lodash._root": {
-              "version": "3.0.1",
-              "bundled": true
-            }
-          }
-        },
-        "lodash._bindcallback": {
-          "version": "3.0.1",
-          "bundled": true
-        },
-        "lodash._cacheindexof": {
-          "version": "3.0.2",
-          "bundled": true
-        },
-        "lodash._createcache": {
-          "version": "3.1.2",
-          "bundled": true,
-          "requires": {
-            "lodash._getnative": "^3.0.0"
-          }
-        },
-        "lodash._getnative": {
-          "version": "3.9.1",
-          "bundled": true
-        },
-        "lodash.clonedeep": {
-          "version": "4.5.0",
-          "bundled": true
-        },
-        "lodash.restparam": {
-          "version": "3.6.1",
-          "bundled": true
-        },
-        "lodash.union": {
-          "version": "4.6.0",
-          "bundled": true
-        },
-        "lodash.uniq": {
-          "version": "4.5.0",
-          "bundled": true
-        },
-        "lodash.without": {
-          "version": "4.4.0",
-          "bundled": true
-        },
-        "lru-cache": {
-          "version": "4.1.1",
-          "bundled": true,
-          "requires": {
-            "pseudomap": "^1.0.2",
-            "yallist": "^2.1.2"
-          },
-          "dependencies": {
-            "pseudomap": {
-              "version": "1.0.2",
-              "bundled": true
-            },
-            "yallist": {
-              "version": "2.1.2",
-              "bundled": true
-            }
-          }
-        },
-        "mississippi": {
-          "version": "1.3.0",
-          "bundled": true,
-          "requires": {
-            "concat-stream": "^1.5.0",
-            "duplexify": "^3.4.2",
-            "end-of-stream": "^1.1.0",
-            "flush-write-stream": "^1.0.0",
-            "from2": "^2.1.0",
-            "parallel-transform": "^1.1.0",
-            "pump": "^1.0.0",
-            "pumpify": "^1.3.3",
-            "stream-each": "^1.1.0",
-            "through2": "^2.0.0"
-          },
-          "dependencies": {
-            "concat-stream": {
-              "version": "1.6.0",
-              "bundled": true,
-              "requires": {
-                "inherits": "^2.0.3",
-                "readable-stream": "^2.2.2",
-                "typedarray": "^0.0.6"
-              },
-              "dependencies": {
-                "typedarray": {
-                  "version": "0.0.6",
-                  "bundled": true
-                }
-              }
-            },
-            "duplexify": {
-              "version": "3.5.0",
-              "bundled": true,
-              "requires": {
-                "end-of-stream": "1.0.0",
-                "inherits": "^2.0.1",
-                "readable-stream": "^2.0.0",
-                "stream-shift": "^1.0.0"
-              },
-              "dependencies": {
-                "end-of-stream": {
-                  "version": "1.0.0",
-                  "bundled": true,
-                  "requires": {
-                    "once": "~1.3.0"
-                  },
-                  "dependencies": {
-                    "once": {
-                      "version": "1.3.3",
-                      "bundled": true,
-                      "requires": {
-                        "wrappy": "1"
-                      }
-                    }
-                  }
-                },
-                "stream-shift": {
-                  "version": "1.0.0",
-                  "bundled": true
-                }
-              }
-            },
-            "end-of-stream": {
-              "version": "1.4.0",
-              "bundled": true,
-              "requires": {
-                "once": "^1.4.0"
-              }
-            },
-            "flush-write-stream": {
-              "version": "1.0.2",
-              "bundled": true,
-              "requires": {
-                "inherits": "^2.0.1",
-                "readable-stream": "^2.0.4"
-              }
-            },
-            "from2": {
-              "version": "2.3.0",
-              "bundled": true,
-              "requires": {
-                "inherits": "^2.0.1",
-                "readable-stream": "^2.0.0"
-              }
-            },
-            "parallel-transform": {
-              "version": "1.1.0",
-              "bundled": true,
-              "requires": {
-                "cyclist": "~0.2.2",
-                "inherits": "^2.0.3",
-                "readable-stream": "^2.1.5"
-              },
-              "dependencies": {
-                "cyclist": {
-                  "version": "0.2.2",
-                  "bundled": true
-                }
-              }
-            },
-            "pump": {
-              "version": "1.0.2",
-              "bundled": true,
-              "requires": {
-                "end-of-stream": "^1.1.0",
-                "once": "^1.3.1"
-              }
-            },
-            "pumpify": {
-              "version": "1.3.5",
-              "bundled": true,
-              "requires": {
-                "duplexify": "^3.1.2",
-                "inherits": "^2.0.1",
-                "pump": "^1.0.0"
-              }
-            },
-            "stream-each": {
-              "version": "1.2.0",
-              "bundled": true,
-              "requires": {
-                "end-of-stream": "^1.1.0",
-                "stream-shift": "^1.0.0"
-              },
-              "dependencies": {
-                "stream-shift": {
-                  "version": "1.0.0",
-                  "bundled": true
-                }
-              }
-            },
-            "through2": {
-              "version": "2.0.3",
-              "bundled": true,
-              "requires": {
-                "readable-stream": "^2.1.5",
-                "xtend": "~4.0.1"
-              },
-              "dependencies": {
-                "xtend": {
-                  "version": "4.0.1",
-                  "bundled": true
-                }
-              }
-            }
-          }
-        },
-        "mkdirp": {
-          "version": "0.5.1",
-          "bundled": true,
-          "requires": {
-            "minimist": "0.0.8"
-          },
-          "dependencies": {
-            "minimist": {
-              "version": "0.0.8",
-              "bundled": true
-            }
-          }
-        },
-        "move-concurrently": {
-          "version": "1.0.1",
-          "bundled": true,
-          "requires": {
-            "aproba": "^1.1.1",
-            "copy-concurrently": "^1.0.0",
-            "fs-write-stream-atomic": "^1.0.8",
-            "mkdirp": "^0.5.1",
-            "rimraf": "^2.5.4",
-            "run-queue": "^1.0.3"
-          },
-          "dependencies": {
-            "copy-concurrently": {
-              "version": "1.0.3",
-              "bundled": true,
-              "requires": {
-                "aproba": "^1.1.1",
-                "fs-write-stream-atomic": "^1.0.8",
-                "iferr": "^0.1.5",
-                "mkdirp": "^0.5.1",
-                "rimraf": "^2.5.4",
-                "run-queue": "^1.0.0"
-              }
-            },
-            "run-queue": {
-              "version": "1.0.3",
-              "bundled": true,
-              "requires": {
-                "aproba": "^1.1.1"
-              }
-            }
-          }
-        },
-        "node-gyp": {
-          "version": "3.6.2",
-          "bundled": true,
-          "requires": {
-            "fstream": "^1.0.0",
-            "glob": "^7.0.3",
-            "graceful-fs": "^4.1.2",
-            "minimatch": "^3.0.2",
-            "mkdirp": "^0.5.0",
-            "nopt": "2 || 3",
-            "npmlog": "0 || 1 || 2 || 3 || 4",
-            "osenv": "0",
-            "request": "2",
-            "rimraf": "2",
-            "semver": "~5.3.0",
-            "tar": "^2.0.0",
-            "which": "1"
-          },
-          "dependencies": {
-            "minimatch": {
-              "version": "3.0.4",
-              "bundled": true,
-              "requires": {
-                "brace-expansion": "^1.1.7"
-              },
-              "dependencies": {
-                "brace-expansion": {
-                  "version": "1.1.8",
-                  "bundled": true,
-                  "requires": {
-                    "balanced-match": "^1.0.0",
-                    "concat-map": "0.0.1"
-                  },
-                  "dependencies": {
-                    "balanced-match": {
-                      "version": "1.0.0",
-                      "bundled": true
-                    },
-                    "concat-map": {
-                      "version": "0.0.1",
-                      "bundled": true
-                    }
-                  }
-                }
-              }
-            },
-            "nopt": {
-              "version": "3.0.6",
-              "bundled": true,
-              "requires": {
-                "abbrev": "1"
-              }
-            }
-          }
-        },
-        "nopt": {
-          "version": "4.0.1",
-          "bundled": true,
-          "requires": {
-            "abbrev": "1",
-            "osenv": "^0.1.4"
-          }
-        },
-        "normalize-package-data": {
-          "version": "2.4.0",
-          "bundled": true,
-          "requires": {
-            "hosted-git-info": "^2.1.4",
-            "is-builtin-module": "^1.0.0",
-            "semver": "2 || 3 || 4 || 5",
-            "validate-npm-package-license": "^3.0.1"
-          },
-          "dependencies": {
-            "is-builtin-module": {
-              "version": "1.0.0",
-              "bundled": true,
-              "requires": {
-                "builtin-modules": "^1.0.0"
-              },
-              "dependencies": {
-                "builtin-modules": {
-                  "version": "1.1.1",
-                  "bundled": true
-                }
-              }
-            }
-          }
-        },
-        "npm-cache-filename": {
-          "version": "1.0.2",
-          "bundled": true
-        },
-        "npm-install-checks": {
-          "version": "3.0.0",
-          "bundled": true,
-          "requires": {
-            "semver": "^2.3.0 || 3.x || 4 || 5"
-          }
-        },
-        "npm-package-arg": {
-          "version": "5.1.2",
-          "bundled": true,
-          "requires": {
-            "hosted-git-info": "^2.4.2",
-            "osenv": "^0.1.4",
-            "semver": "^5.1.0",
-            "validate-npm-package-name": "^3.0.0"
-          }
-        },
-        "npm-registry-client": {
-          "version": "8.4.0",
-          "bundled": true,
-          "requires": {
-            "concat-stream": "^1.5.2",
-            "graceful-fs": "^4.1.6",
-            "normalize-package-data": "~1.0.1 || ^2.0.0",
-            "npm-package-arg": "^3.0.0 || ^4.0.0 || ^5.0.0",
-            "npmlog": "2 || ^3.1.0 || ^4.0.0",
-            "once": "^1.3.3",
-            "request": "^2.74.0",
-            "retry": "^0.10.0",
-            "semver": "2 >=2.2.1 || 3.x || 4 || 5",
-            "slide": "^1.1.3",
-            "ssri": "^4.1.2"
-          },
-          "dependencies": {
-            "concat-stream": {
-              "version": "1.6.0",
-              "bundled": true,
-              "requires": {
-                "inherits": "^2.0.3",
-                "readable-stream": "^2.2.2",
-                "typedarray": "^0.0.6"
-              },
-              "dependencies": {
-                "typedarray": {
-                  "version": "0.0.6",
-                  "bundled": true
-                }
-              }
-            }
-          }
-        },
-        "npm-user-validate": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "npmlog": {
-          "version": "4.1.2",
-          "bundled": true,
-          "requires": {
-            "are-we-there-yet": "~1.1.2",
-            "console-control-strings": "~1.1.0",
-            "gauge": "~2.7.3",
-            "set-blocking": "~2.0.0"
-          },
-          "dependencies": {
-            "are-we-there-yet": {
-              "version": "1.1.4",
-              "bundled": true,
-              "requires": {
-                "delegates": "^1.0.0",
-                "readable-stream": "^2.0.6"
-              },
-              "dependencies": {
-                "delegates": {
-                  "version": "1.0.0",
-                  "bundled": true
-                }
-              }
-            },
-            "console-control-strings": {
-              "version": "1.1.0",
-              "bundled": true
-            },
-            "gauge": {
-              "version": "2.7.4",
-              "bundled": true,
-              "requires": {
-                "aproba": "^1.0.3",
-                "console-control-strings": "^1.0.0",
-                "has-unicode": "^2.0.0",
-                "object-assign": "^4.1.0",
-                "signal-exit": "^3.0.0",
-                "string-width": "^1.0.1",
-                "strip-ansi": "^3.0.1",
-                "wide-align": "^1.1.0"
-              },
-              "dependencies": {
-                "object-assign": {
-                  "version": "4.1.1",
-                  "bundled": true
-                },
-                "signal-exit": {
-                  "version": "3.0.2",
-                  "bundled": true
-                },
-                "string-width": {
-                  "version": "1.0.2",
-                  "bundled": true,
-                  "requires": {
-                    "code-point-at": "^1.0.0",
-                    "is-fullwidth-code-point": "^1.0.0",
-                    "strip-ansi": "^3.0.0"
-                  },
-                  "dependencies": {
-                    "code-point-at": {
-                      "version": "1.1.0",
-                      "bundled": true
-                    },
-                    "is-fullwidth-code-point": {
-                      "version": "1.0.0",
-                      "bundled": true,
-                      "requires": {
-                        "number-is-nan": "^1.0.0"
-                      },
-                      "dependencies": {
-                        "number-is-nan": {
-                          "version": "1.0.1",
-                          "bundled": true
-                        }
-                      }
-                    }
-                  }
-                },
-                "strip-ansi": {
-                  "version": "3.0.1",
-                  "bundled": true,
-                  "requires": {
-                    "ansi-regex": "^2.0.0"
-                  },
-                  "dependencies": {
-                    "ansi-regex": {
-                      "version": "2.1.1",
-                      "bundled": true
-                    }
-                  }
-                },
-                "wide-align": {
-                  "version": "1.1.2",
-                  "bundled": true,
-                  "requires": {
-                    "string-width": "^1.0.2"
-                  }
-                }
-              }
-            },
-            "set-blocking": {
-              "version": "2.0.0",
-              "bundled": true
-            }
-          }
-        },
-        "once": {
-          "version": "1.4.0",
-          "bundled": true,
-          "requires": {
-            "wrappy": "1"
-          }
-        },
-        "opener": {
-          "version": "1.4.3",
-          "bundled": true
-        },
-        "osenv": {
-          "version": "0.1.4",
-          "bundled": true,
-          "requires": {
-            "os-homedir": "^1.0.0",
-            "os-tmpdir": "^1.0.0"
-          },
-          "dependencies": {
-            "os-homedir": {
-              "version": "1.0.2",
-              "bundled": true
-            },
-            "os-tmpdir": {
-              "version": "1.0.2",
-              "bundled": true
-            }
-          }
-        },
-        "pacote": {
-          "version": "2.7.38",
-          "bundled": true,
-          "requires": {
-            "bluebird": "^3.5.0",
-            "cacache": "^9.2.9",
-            "glob": "^7.1.2",
-            "lru-cache": "^4.1.1",
-            "make-fetch-happen": "^2.4.13",
-            "minimatch": "^3.0.4",
-            "mississippi": "^1.2.0",
-            "normalize-package-data": "^2.4.0",
-            "npm-package-arg": "^5.1.2",
-            "npm-pick-manifest": "^1.0.4",
-            "osenv": "^0.1.4",
-            "promise-inflight": "^1.0.1",
-            "promise-retry": "^1.1.1",
-            "protoduck": "^4.0.0",
-            "safe-buffer": "^5.1.1",
-            "semver": "^5.3.0",
-            "ssri": "^4.1.6",
-            "tar-fs": "^1.15.3",
-            "tar-stream": "^1.5.4",
-            "unique-filename": "^1.1.0",
-            "which": "^1.2.12"
-          },
-          "dependencies": {
-            "make-fetch-happen": {
-              "version": "2.4.13",
-              "bundled": true,
-              "requires": {
-                "agentkeepalive": "^3.3.0",
-                "cacache": "^9.2.9",
-                "http-cache-semantics": "^3.7.3",
-                "http-proxy-agent": "^2.0.0",
-                "https-proxy-agent": "^2.0.0",
-                "lru-cache": "^4.1.1",
-                "mississippi": "^1.2.0",
-                "node-fetch-npm": "^2.0.1",
-                "promise-retry": "^1.1.1",
-                "socks-proxy-agent": "^3.0.0",
-                "ssri": "^4.1.6"
-              },
-              "dependencies": {
-                "agentkeepalive": {
-                  "version": "3.3.0",
-                  "bundled": true,
-                  "requires": {
-                    "humanize-ms": "^1.2.1"
-                  },
-                  "dependencies": {
-                    "humanize-ms": {
-                      "version": "1.2.1",
-                      "bundled": true,
-                      "requires": {
-                        "ms": "^2.0.0"
-                      },
-                      "dependencies": {
-                        "ms": {
-                          "version": "2.0.0",
-                          "bundled": true
-                        }
-                      }
-                    }
-                  }
-                },
-                "http-cache-semantics": {
-                  "version": "3.7.3",
-                  "bundled": true
-                },
-                "http-proxy-agent": {
-                  "version": "2.0.0",
-                  "bundled": true,
-                  "requires": {
-                    "agent-base": "4",
-                    "debug": "2"
-                  },
-                  "dependencies": {
-                    "agent-base": {
-                      "version": "4.1.0",
-                      "bundled": true,
-                      "requires": {
-                        "es6-promisify": "^5.0.0"
-                      },
-                      "dependencies": {
-                        "es6-promisify": {
-                          "version": "5.0.0",
-                          "bundled": true,
-                          "requires": {
-                            "es6-promise": "^4.0.3"
-                          },
-                          "dependencies": {
-                            "es6-promise": {
-                              "version": "4.1.1",
-                              "bundled": true
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "debug": {
-                      "version": "2.6.8",
-                      "bundled": true,
-                      "requires": {
-                        "ms": "2.0.0"
-                      },
-                      "dependencies": {
-                        "ms": {
-                          "version": "2.0.0",
-                          "bundled": true
-                        }
-                      }
-                    }
-                  }
-                },
-                "https-proxy-agent": {
-                  "version": "2.0.0",
-                  "bundled": true,
-                  "requires": {
-                    "agent-base": "^4.1.0",
-                    "debug": "^2.4.1"
-                  },
-                  "dependencies": {
-                    "agent-base": {
-                      "version": "4.1.0",
-                      "bundled": true,
-                      "requires": {
-                        "es6-promisify": "^5.0.0"
-                      },
-                      "dependencies": {
-                        "es6-promisify": {
-                          "version": "5.0.0",
-                          "bundled": true,
-                          "requires": {
-                            "es6-promise": "^4.0.3"
-                          },
-                          "dependencies": {
-                            "es6-promise": {
-                              "version": "4.1.1",
-                              "bundled": true
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "debug": {
-                      "version": "2.6.8",
-                      "bundled": true,
-                      "requires": {
-                        "ms": "2.0.0"
-                      },
-                      "dependencies": {
-                        "ms": {
-                          "version": "2.0.0",
-                          "bundled": true
-                        }
-                      }
-                    }
-                  }
-                },
-                "node-fetch-npm": {
-                  "version": "2.0.1",
-                  "bundled": true,
-                  "requires": {
-                    "encoding": "^0.1.11",
-                    "json-parse-helpfulerror": "^1.0.3",
-                    "safe-buffer": "^5.0.1"
-                  },
-                  "dependencies": {
-                    "encoding": {
-                      "version": "0.1.12",
-                      "bundled": true,
-                      "requires": {
-                        "iconv-lite": "~0.4.13"
-                      },
-                      "dependencies": {
-                        "iconv-lite": {
-                          "version": "0.4.18",
-                          "bundled": true
-                        }
-                      }
-                    },
-                    "json-parse-helpfulerror": {
-                      "version": "1.0.3",
-                      "bundled": true,
-                      "requires": {
-                        "jju": "^1.1.0"
-                      },
-                      "dependencies": {
-                        "jju": {
-                          "version": "1.3.0",
-                          "bundled": true
-                        }
-                      }
-                    }
-                  }
-                },
-                "socks-proxy-agent": {
-                  "version": "3.0.0",
-                  "bundled": true,
-                  "requires": {
-                    "agent-base": "^4.0.1",
-                    "socks": "^1.1.10"
-                  },
-                  "dependencies": {
-                    "agent-base": {
-                      "version": "4.1.0",
-                      "bundled": true,
-                      "requires": {
-                        "es6-promisify": "^5.0.0"
-                      },
-                      "dependencies": {
-                        "es6-promisify": {
-                          "version": "5.0.0",
-                          "bundled": true,
-                          "requires": {
-                            "es6-promise": "^4.0.3"
-                          },
-                          "dependencies": {
-                            "es6-promise": {
-                              "version": "4.1.1",
-                              "bundled": true
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "socks": {
-                      "version": "1.1.10",
-                      "bundled": true,
-                      "requires": {
-                        "ip": "^1.1.4",
-                        "smart-buffer": "^1.0.13"
-                      },
-                      "dependencies": {
-                        "ip": {
-                          "version": "1.1.5",
-                          "bundled": true
-                        },
-                        "smart-buffer": {
-                          "version": "1.1.15",
-                          "bundled": true
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            },
-            "minimatch": {
-              "version": "3.0.4",
-              "bundled": true,
-              "requires": {
-                "brace-expansion": "^1.1.7"
-              },
-              "dependencies": {
-                "brace-expansion": {
-                  "version": "1.1.8",
-                  "bundled": true,
-                  "requires": {
-                    "balanced-match": "^1.0.0",
-                    "concat-map": "0.0.1"
-                  },
-                  "dependencies": {
-                    "balanced-match": {
-                      "version": "1.0.0",
-                      "bundled": true
-                    },
-                    "concat-map": {
-                      "version": "0.0.1",
-                      "bundled": true
-                    }
-                  }
-                }
-              }
-            },
-            "npm-pick-manifest": {
-              "version": "1.0.4",
-              "bundled": true,
-              "requires": {
-                "npm-package-arg": "^5.1.2",
-                "semver": "^5.3.0"
-              }
-            },
-            "promise-retry": {
-              "version": "1.1.1",
-              "bundled": true,
-              "requires": {
-                "err-code": "^1.0.0",
-                "retry": "^0.10.0"
-              },
-              "dependencies": {
-                "err-code": {
-                  "version": "1.1.2",
-                  "bundled": true
-                }
-              }
-            },
-            "protoduck": {
-              "version": "4.0.0",
-              "bundled": true,
-              "requires": {
-                "genfun": "^4.0.1"
-              },
-              "dependencies": {
-                "genfun": {
-                  "version": "4.0.1",
-                  "bundled": true
-                }
-              }
-            },
-            "tar-fs": {
-              "version": "1.15.3",
-              "bundled": true,
-              "requires": {
-                "chownr": "^1.0.1",
-                "mkdirp": "^0.5.1",
-                "pump": "^1.0.0",
-                "tar-stream": "^1.1.2"
-              },
-              "dependencies": {
-                "pump": {
-                  "version": "1.0.2",
-                  "bundled": true,
-                  "requires": {
-                    "end-of-stream": "^1.1.0",
-                    "once": "^1.3.1"
-                  },
-                  "dependencies": {
-                    "end-of-stream": {
-                      "version": "1.4.0",
-                      "bundled": true,
-                      "requires": {
-                        "once": "^1.4.0"
-                      }
-                    }
-                  }
-                }
-              }
-            },
-            "tar-stream": {
-              "version": "1.5.4",
-              "bundled": true,
-              "requires": {
-                "bl": "^1.0.0",
-                "end-of-stream": "^1.0.0",
-                "readable-stream": "^2.0.0",
-                "xtend": "^4.0.0"
-              },
-              "dependencies": {
-                "bl": {
-                  "version": "1.2.1",
-                  "bundled": true,
-                  "requires": {
-                    "readable-stream": "^2.0.5"
-                  }
-                },
-                "end-of-stream": {
-                  "version": "1.4.0",
-                  "bundled": true,
-                  "requires": {
-                    "once": "^1.4.0"
-                  }
-                },
-                "xtend": {
-                  "version": "4.0.1",
-                  "bundled": true
-                }
-              }
-            }
-          }
-        },
-        "path-is-inside": {
-          "version": "1.0.2",
-          "bundled": true
-        },
-        "promise-inflight": {
-          "version": "1.0.1",
-          "bundled": true
-        },
-        "read": {
-          "version": "1.0.7",
-          "bundled": true,
-          "requires": {
-            "mute-stream": "~0.0.4"
-          },
-          "dependencies": {
-            "mute-stream": {
-              "version": "0.0.7",
-              "bundled": true
-            }
-          }
-        },
-        "read-cmd-shim": {
-          "version": "1.0.1",
-          "bundled": true,
-          "requires": {
-            "graceful-fs": "^4.1.2"
-          }
-        },
-        "read-installed": {
-          "version": "4.0.3",
-          "bundled": true,
-          "requires": {
-            "debuglog": "^1.0.1",
-            "graceful-fs": "^4.1.2",
-            "read-package-json": "^2.0.0",
-            "readdir-scoped-modules": "^1.0.0",
-            "semver": "2 || 3 || 4 || 5",
-            "slide": "~1.1.3",
-            "util-extend": "^1.0.1"
-          },
-          "dependencies": {
-            "util-extend": {
-              "version": "1.0.3",
-              "bundled": true
-            }
-          }
-        },
-        "read-package-json": {
-          "version": "2.0.9",
-          "bundled": true,
-          "requires": {
-            "glob": "^7.1.1",
-            "graceful-fs": "^4.1.2",
-            "json-parse-helpfulerror": "^1.0.2",
-            "normalize-package-data": "^2.0.0"
-          },
-          "dependencies": {
-            "json-parse-helpfulerror": {
-              "version": "1.0.3",
-              "bundled": true,
-              "requires": {
-                "jju": "^1.1.0"
-              },
-              "dependencies": {
-                "jju": {
-                  "version": "1.3.0",
-                  "bundled": true
-                }
-              }
-            }
-          }
-        },
-        "read-package-tree": {
-          "version": "5.1.6",
-          "bundled": true,
-          "requires": {
-            "debuglog": "^1.0.1",
-            "dezalgo": "^1.0.0",
-            "once": "^1.3.0",
-            "read-package-json": "^2.0.0",
-            "readdir-scoped-modules": "^1.0.0"
-          }
-        },
-        "readable-stream": {
-          "version": "2.3.2",
-          "bundled": true,
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~1.0.6",
-            "safe-buffer": "~5.1.0",
-            "string_decoder": "~1.0.0",
-            "util-deprecate": "~1.0.1"
-          },
-          "dependencies": {
-            "core-util-is": {
-              "version": "1.0.2",
-              "bundled": true
-            },
-            "isarray": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "process-nextick-args": {
-              "version": "1.0.7",
-              "bundled": true
-            },
-            "string_decoder": {
-              "version": "1.0.3",
-              "bundled": true,
-              "requires": {
-                "safe-buffer": "~5.1.0"
-              }
-            },
-            "util-deprecate": {
-              "version": "1.0.2",
-              "bundled": true
-            }
-          }
-        },
-        "readdir-scoped-modules": {
-          "version": "1.0.2",
-          "bundled": true,
-          "requires": {
-            "debuglog": "^1.0.1",
-            "dezalgo": "^1.0.0",
-            "graceful-fs": "^4.1.2",
-            "once": "^1.3.0"
-          }
-        },
-        "request": {
-          "version": "2.81.0",
-          "bundled": true,
-          "requires": {
-            "aws-sign2": "~0.6.0",
-            "aws4": "^1.2.1",
-            "caseless": "~0.12.0",
-            "combined-stream": "~1.0.5",
-            "extend": "~3.0.0",
-            "forever-agent": "~0.6.1",
-            "form-data": "~2.1.1",
-            "har-validator": "~4.2.1",
-            "hawk": "~3.1.3",
-            "http-signature": "~1.1.0",
-            "is-typedarray": "~1.0.0",
-            "isstream": "~0.1.2",
-            "json-stringify-safe": "~5.0.1",
-            "mime-types": "~2.1.7",
-            "oauth-sign": "~0.8.1",
-            "performance-now": "^0.2.0",
-            "qs": "~6.4.0",
-            "safe-buffer": "^5.0.1",
-            "stringstream": "~0.0.4",
-            "tough-cookie": "~2.3.0",
-            "tunnel-agent": "^0.6.0",
-            "uuid": "^3.0.0"
-          },
-          "dependencies": {
-            "aws-sign2": {
-              "version": "0.6.0",
-              "bundled": true
-            },
-            "aws4": {
-              "version": "1.6.0",
-              "bundled": true
-            },
-            "caseless": {
-              "version": "0.12.0",
-              "bundled": true
-            },
-            "combined-stream": {
-              "version": "1.0.5",
-              "bundled": true,
-              "requires": {
-                "delayed-stream": "~1.0.0"
-              },
-              "dependencies": {
-                "delayed-stream": {
-                  "version": "1.0.0",
-                  "bundled": true
-                }
-              }
-            },
-            "extend": {
-              "version": "3.0.1",
-              "bundled": true
-            },
-            "forever-agent": {
-              "version": "0.6.1",
-              "bundled": true
-            },
-            "form-data": {
-              "version": "2.1.4",
-              "bundled": true,
-              "requires": {
-                "asynckit": "^0.4.0",
-                "combined-stream": "^1.0.5",
-                "mime-types": "^2.1.12"
-              },
-              "dependencies": {
-                "asynckit": {
-                  "version": "0.4.0",
-                  "bundled": true
-                }
-              }
-            },
-            "har-validator": {
-              "version": "4.2.1",
-              "bundled": true,
-              "requires": {
-                "ajv": "^4.9.1",
-                "har-schema": "^1.0.5"
-              },
-              "dependencies": {
-                "ajv": {
-                  "version": "4.11.8",
-                  "bundled": true,
-                  "requires": {
-                    "co": "^4.6.0",
-                    "json-stable-stringify": "^1.0.1"
-                  },
-                  "dependencies": {
-                    "co": {
-                      "version": "4.6.0",
-                      "bundled": true
-                    },
-                    "json-stable-stringify": {
-                      "version": "1.0.1",
-                      "bundled": true,
-                      "requires": {
-                        "jsonify": "~0.0.0"
-                      },
-                      "dependencies": {
-                        "jsonify": {
-                          "version": "0.0.0",
-                          "bundled": true
-                        }
-                      }
-                    }
-                  }
-                },
-                "har-schema": {
-                  "version": "1.0.5",
-                  "bundled": true
-                }
-              }
-            },
-            "hawk": {
-              "version": "3.1.3",
-              "bundled": true,
-              "requires": {
-                "boom": "2.x.x",
-                "cryptiles": "2.x.x",
-                "hoek": "2.x.x",
-                "sntp": "1.x.x"
-              },
-              "dependencies": {
-                "boom": {
-                  "version": "2.10.1",
-                  "bundled": true,
-                  "requires": {
-                    "hoek": "2.x.x"
-                  }
-                },
-                "cryptiles": {
-                  "version": "2.0.5",
-                  "bundled": true,
-                  "requires": {
-                    "boom": "2.x.x"
-                  }
-                },
-                "hoek": {
-                  "version": "2.16.3",
-                  "bundled": true
-                },
-                "sntp": {
-                  "version": "1.0.9",
-                  "bundled": true,
-                  "requires": {
-                    "hoek": "2.x.x"
-                  }
-                }
-              }
-            },
-            "http-signature": {
-              "version": "1.1.1",
-              "bundled": true,
-              "requires": {
-                "assert-plus": "^0.2.0",
-                "jsprim": "^1.2.2",
-                "sshpk": "^1.7.0"
-              },
-              "dependencies": {
-                "assert-plus": {
-                  "version": "0.2.0",
-                  "bundled": true
-                },
-                "jsprim": {
-                  "version": "1.4.0",
-                  "bundled": true,
-                  "requires": {
-                    "assert-plus": "1.0.0",
-                    "extsprintf": "1.0.2",
-                    "json-schema": "0.2.3",
-                    "verror": "1.3.6"
-                  },
-                  "dependencies": {
-                    "assert-plus": {
-                      "version": "1.0.0",
-                      "bundled": true
-                    },
-                    "extsprintf": {
-                      "version": "1.0.2",
-                      "bundled": true
-                    },
-                    "json-schema": {
-                      "version": "0.2.3",
-                      "bundled": true
-                    },
-                    "verror": {
-                      "version": "1.3.6",
-                      "bundled": true,
-                      "requires": {
-                        "extsprintf": "1.0.2"
-                      }
-                    }
-                  }
-                },
-                "sshpk": {
-                  "version": "1.13.1",
-                  "bundled": true,
-                  "requires": {
-                    "asn1": "~0.2.3",
-                    "assert-plus": "^1.0.0",
-                    "bcrypt-pbkdf": "^1.0.0",
-                    "dashdash": "^1.12.0",
-                    "ecc-jsbn": "~0.1.1",
-                    "getpass": "^0.1.1",
-                    "jsbn": "~0.1.0",
-                    "tweetnacl": "~0.14.0"
-                  },
-                  "dependencies": {
-                    "asn1": {
-                      "version": "0.2.3",
-                      "bundled": true
-                    },
-                    "assert-plus": {
-                      "version": "1.0.0",
-                      "bundled": true
-                    },
-                    "bcrypt-pbkdf": {
-                      "version": "1.0.1",
-                      "bundled": true,
-                      "optional": true,
-                      "requires": {
-                        "tweetnacl": "^0.14.3"
-                      }
-                    },
-                    "dashdash": {
-                      "version": "1.14.1",
-                      "bundled": true,
-                      "requires": {
-                        "assert-plus": "^1.0.0"
-                      }
-                    },
-                    "ecc-jsbn": {
-                      "version": "0.1.1",
-                      "bundled": true,
-                      "optional": true,
-                      "requires": {
-                        "jsbn": "~0.1.0"
-                      }
-                    },
-                    "getpass": {
-                      "version": "0.1.7",
-                      "bundled": true,
-                      "requires": {
-                        "assert-plus": "^1.0.0"
-                      }
-                    },
-                    "jsbn": {
-                      "version": "0.1.1",
-                      "bundled": true,
-                      "optional": true
-                    },
-                    "tweetnacl": {
-                      "version": "0.14.5",
-                      "bundled": true,
-                      "optional": true
-                    }
-                  }
-                }
-              }
-            },
-            "is-typedarray": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "isstream": {
-              "version": "0.1.2",
-              "bundled": true
-            },
-            "json-stringify-safe": {
-              "version": "5.0.1",
-              "bundled": true
-            },
-            "mime-types": {
-              "version": "2.1.15",
-              "bundled": true,
-              "requires": {
-                "mime-db": "~1.27.0"
-              },
-              "dependencies": {
-                "mime-db": {
-                  "version": "1.27.0",
-                  "bundled": true
-                }
-              }
-            },
-            "oauth-sign": {
-              "version": "0.8.2",
-              "bundled": true
-            },
-            "performance-now": {
-              "version": "0.2.0",
-              "bundled": true
-            },
-            "qs": {
-              "version": "6.4.0",
-              "bundled": true
-            },
-            "stringstream": {
-              "version": "0.0.5",
-              "bundled": true
-            },
-            "tough-cookie": {
-              "version": "2.3.2",
-              "bundled": true,
-              "requires": {
-                "punycode": "^1.4.1"
-              },
-              "dependencies": {
-                "punycode": {
-                  "version": "1.4.1",
-                  "bundled": true
-                }
-              }
-            },
-            "tunnel-agent": {
-              "version": "0.6.0",
-              "bundled": true,
-              "requires": {
-                "safe-buffer": "^5.0.1"
-              }
-            }
-          }
-        },
-        "retry": {
-          "version": "0.10.1",
-          "bundled": true
-        },
-        "rimraf": {
-          "version": "2.6.1",
-          "bundled": true,
-          "requires": {
-            "glob": "^7.0.5"
-          }
-        },
-        "safe-buffer": {
-          "version": "5.1.1",
-          "bundled": true
-        },
-        "semver": {
-          "version": "5.3.0",
-          "bundled": true
-        },
-        "sha": {
-          "version": "2.0.1",
-          "bundled": true,
-          "requires": {
-            "graceful-fs": "^4.1.2",
-            "readable-stream": "^2.0.2"
-          }
-        },
-        "slide": {
-          "version": "1.1.6",
-          "bundled": true
-        },
-        "sorted-object": {
-          "version": "2.0.1",
-          "bundled": true
-        },
-        "sorted-union-stream": {
-          "version": "2.1.3",
-          "bundled": true,
-          "requires": {
-            "from2": "^1.3.0",
-            "stream-iterate": "^1.1.0"
-          },
-          "dependencies": {
-            "from2": {
-              "version": "1.3.0",
-              "bundled": true,
-              "requires": {
-                "inherits": "~2.0.1",
-                "readable-stream": "~1.1.10"
-              },
-              "dependencies": {
-                "readable-stream": {
-                  "version": "1.1.14",
-                  "bundled": true,
-                  "requires": {
-                    "core-util-is": "~1.0.0",
-                    "inherits": "~2.0.1",
-                    "isarray": "0.0.1",
-                    "string_decoder": "~0.10.x"
-                  },
-                  "dependencies": {
-                    "core-util-is": {
-                      "version": "1.0.2",
-                      "bundled": true
-                    },
-                    "isarray": {
-                      "version": "0.0.1",
-                      "bundled": true
-                    },
-                    "string_decoder": {
-                      "version": "0.10.31",
-                      "bundled": true
-                    }
-                  }
-                }
-              }
-            },
-            "stream-iterate": {
-              "version": "1.2.0",
-              "bundled": true,
-              "requires": {
-                "readable-stream": "^2.1.5",
-                "stream-shift": "^1.0.0"
-              },
-              "dependencies": {
-                "stream-shift": {
-                  "version": "1.0.0",
-                  "bundled": true
-                }
-              }
-            }
-          }
-        },
-        "ssri": {
-          "version": "4.1.6",
-          "bundled": true,
-          "requires": {
-            "safe-buffer": "^5.1.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "4.0.0",
-          "bundled": true,
-          "requires": {
-            "ansi-regex": "^3.0.0"
-          },
-          "dependencies": {
-            "ansi-regex": {
-              "version": "3.0.0",
-              "bundled": true
-            }
-          }
-        },
-        "tar": {
-          "version": "2.2.1",
-          "bundled": true,
-          "requires": {
-            "block-stream": "*",
-            "fstream": "^1.0.2",
-            "inherits": "2"
-          },
-          "dependencies": {
-            "block-stream": {
-              "version": "0.0.9",
-              "bundled": true,
-              "requires": {
-                "inherits": "~2.0.0"
-              }
-            }
-          }
-        },
-        "text-table": {
-          "version": "0.2.0",
-          "bundled": true
-        },
-        "uid-number": {
-          "version": "0.0.6",
-          "bundled": true
-        },
-        "umask": {
-          "version": "1.1.0",
-          "bundled": true
-        },
-        "unique-filename": {
-          "version": "1.1.0",
-          "bundled": true,
-          "requires": {
-            "unique-slug": "^2.0.0"
-          },
-          "dependencies": {
-            "unique-slug": {
-              "version": "2.0.0",
-              "bundled": true,
-              "requires": {
-                "imurmurhash": "^0.1.4"
-              }
-            }
-          }
-        },
-        "unpipe": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "update-notifier": {
-          "version": "2.2.0",
-          "bundled": true,
-          "requires": {
-            "boxen": "^1.0.0",
-            "chalk": "^1.0.0",
-            "configstore": "^3.0.0",
-            "import-lazy": "^2.1.0",
-            "is-npm": "^1.0.0",
-            "latest-version": "^3.0.0",
-            "semver-diff": "^2.0.0",
-            "xdg-basedir": "^3.0.0"
-          },
-          "dependencies": {
-            "boxen": {
-              "version": "1.1.0",
-              "bundled": true,
-              "requires": {
-                "ansi-align": "^2.0.0",
-                "camelcase": "^4.0.0",
-                "chalk": "^1.1.1",
-                "cli-boxes": "^1.0.0",
-                "string-width": "^2.0.0",
-                "term-size": "^0.1.0",
-                "widest-line": "^1.0.0"
-              },
-              "dependencies": {
-                "ansi-align": {
-                  "version": "2.0.0",
-                  "bundled": true,
-                  "requires": {
-                    "string-width": "^2.0.0"
-                  }
-                },
-                "camelcase": {
-                  "version": "4.1.0",
-                  "bundled": true
-                },
-                "cli-boxes": {
-                  "version": "1.0.0",
-                  "bundled": true
-                },
-                "string-width": {
-                  "version": "2.1.0",
-                  "bundled": true,
-                  "requires": {
-                    "is-fullwidth-code-point": "^2.0.0",
-                    "strip-ansi": "^4.0.0"
-                  },
-                  "dependencies": {
-                    "is-fullwidth-code-point": {
-                      "version": "2.0.0",
-                      "bundled": true
-                    },
-                    "strip-ansi": {
-                      "version": "4.0.0",
-                      "bundled": true,
-                      "requires": {
-                        "ansi-regex": "^3.0.0"
-                      }
-                    }
-                  }
-                },
-                "term-size": {
-                  "version": "0.1.1",
-                  "bundled": true,
-                  "requires": {
-                    "execa": "^0.4.0"
-                  },
-                  "dependencies": {
-                    "execa": {
-                      "version": "0.4.0",
-                      "bundled": true,
-                      "requires": {
-                        "cross-spawn-async": "^2.1.1",
-                        "is-stream": "^1.1.0",
-                        "npm-run-path": "^1.0.0",
-                        "object-assign": "^4.0.1",
-                        "path-key": "^1.0.0",
-                        "strip-eof": "^1.0.0"
-                      },
-                      "dependencies": {
-                        "cross-spawn-async": {
-                          "version": "2.2.5",
-                          "bundled": true,
-                          "requires": {
-                            "lru-cache": "^4.0.0",
-                            "which": "^1.2.8"
-                          }
-                        },
-                        "is-stream": {
-                          "version": "1.1.0",
-                          "bundled": true
-                        },
-                        "npm-run-path": {
-                          "version": "1.0.0",
-                          "bundled": true,
-                          "requires": {
-                            "path-key": "^1.0.0"
-                          }
-                        },
-                        "object-assign": {
-                          "version": "4.1.1",
-                          "bundled": true
-                        },
-                        "path-key": {
-                          "version": "1.0.0",
-                          "bundled": true
-                        },
-                        "strip-eof": {
-                          "version": "1.0.0",
-                          "bundled": true
-                        }
-                      }
-                    }
-                  }
-                },
-                "widest-line": {
-                  "version": "1.0.0",
-                  "bundled": true,
-                  "requires": {
-                    "string-width": "^1.0.1"
-                  },
-                  "dependencies": {
-                    "string-width": {
-                      "version": "1.0.2",
-                      "bundled": true,
-                      "requires": {
-                        "code-point-at": "^1.0.0",
-                        "is-fullwidth-code-point": "^1.0.0",
-                        "strip-ansi": "^3.0.0"
-                      },
-                      "dependencies": {
-                        "code-point-at": {
-                          "version": "1.1.0",
-                          "bundled": true
-                        },
-                        "is-fullwidth-code-point": {
-                          "version": "1.0.0",
-                          "bundled": true,
-                          "requires": {
-                            "number-is-nan": "^1.0.0"
-                          },
-                          "dependencies": {
-                            "number-is-nan": {
-                              "version": "1.0.1",
-                              "bundled": true
-                            }
-                          }
-                        },
-                        "strip-ansi": {
-                          "version": "3.0.1",
-                          "bundled": true,
-                          "requires": {
-                            "ansi-regex": "^2.0.0"
-                          },
-                          "dependencies": {
-                            "ansi-regex": {
-                              "version": "2.1.1",
-                              "bundled": true
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            },
-            "chalk": {
-              "version": "1.1.3",
-              "bundled": true,
-              "requires": {
-                "ansi-styles": "^2.2.1",
-                "escape-string-regexp": "^1.0.2",
-                "has-ansi": "^2.0.0",
-                "strip-ansi": "^3.0.0",
-                "supports-color": "^2.0.0"
-              },
-              "dependencies": {
-                "ansi-styles": {
-                  "version": "2.2.1",
-                  "bundled": true
-                },
-                "escape-string-regexp": {
-                  "version": "1.0.5",
-                  "bundled": true
-                },
-                "has-ansi": {
-                  "version": "2.0.0",
-                  "bundled": true,
-                  "requires": {
-                    "ansi-regex": "^2.0.0"
-                  },
-                  "dependencies": {
-                    "ansi-regex": {
-                      "version": "2.1.1",
-                      "bundled": true
-                    }
-                  }
-                },
-                "strip-ansi": {
-                  "version": "3.0.1",
-                  "bundled": true,
-                  "requires": {
-                    "ansi-regex": "^2.0.0"
-                  },
-                  "dependencies": {
-                    "ansi-regex": {
-                      "version": "2.1.1",
-                      "bundled": true
-                    }
-                  }
-                },
-                "supports-color": {
-                  "version": "2.0.0",
-                  "bundled": true
-                }
-              }
-            },
-            "configstore": {
-              "version": "3.1.0",
-              "bundled": true,
-              "requires": {
-                "dot-prop": "^4.1.0",
-                "graceful-fs": "^4.1.2",
-                "make-dir": "^1.0.0",
-                "unique-string": "^1.0.0",
-                "write-file-atomic": "^2.0.0",
-                "xdg-basedir": "^3.0.0"
-              },
-              "dependencies": {
-                "dot-prop": {
-                  "version": "4.1.1",
-                  "bundled": true,
-                  "requires": {
-                    "is-obj": "^1.0.0"
-                  },
-                  "dependencies": {
-                    "is-obj": {
-                      "version": "1.0.1",
-                      "bundled": true
-                    }
-                  }
-                },
-                "make-dir": {
-                  "version": "1.0.0",
-                  "bundled": true,
-                  "requires": {
-                    "pify": "^2.3.0"
-                  },
-                  "dependencies": {
-                    "pify": {
-                      "version": "2.3.0",
-                      "bundled": true
-                    }
-                  }
-                },
-                "unique-string": {
-                  "version": "1.0.0",
-                  "bundled": true,
-                  "requires": {
-                    "crypto-random-string": "^1.0.0"
-                  },
-                  "dependencies": {
-                    "crypto-random-string": {
-                      "version": "1.0.0",
-                      "bundled": true
-                    }
-                  }
-                }
-              }
-            },
-            "import-lazy": {
-              "version": "2.1.0",
-              "bundled": true
-            },
-            "is-npm": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "latest-version": {
-              "version": "3.1.0",
-              "bundled": true,
-              "requires": {
-                "package-json": "^4.0.0"
-              },
-              "dependencies": {
-                "package-json": {
-                  "version": "4.0.1",
-                  "bundled": true,
-                  "requires": {
-                    "got": "^6.7.1",
-                    "registry-auth-token": "^3.0.1",
-                    "registry-url": "^3.0.3",
-                    "semver": "^5.1.0"
-                  },
-                  "dependencies": {
-                    "got": {
-                      "version": "6.7.1",
-                      "bundled": true,
-                      "requires": {
-                        "create-error-class": "^3.0.0",
-                        "duplexer3": "^0.1.4",
-                        "get-stream": "^3.0.0",
-                        "is-redirect": "^1.0.0",
-                        "is-retry-allowed": "^1.0.0",
-                        "is-stream": "^1.0.0",
-                        "lowercase-keys": "^1.0.0",
-                        "safe-buffer": "^5.0.1",
-                        "timed-out": "^4.0.0",
-                        "unzip-response": "^2.0.1",
-                        "url-parse-lax": "^1.0.0"
-                      },
-                      "dependencies": {
-                        "create-error-class": {
-                          "version": "3.0.2",
-                          "bundled": true,
-                          "requires": {
-                            "capture-stack-trace": "^1.0.0"
-                          },
-                          "dependencies": {
-                            "capture-stack-trace": {
-                              "version": "1.0.0",
-                              "bundled": true
-                            }
-                          }
-                        },
-                        "duplexer3": {
-                          "version": "0.1.4",
-                          "bundled": true
-                        },
-                        "get-stream": {
-                          "version": "3.0.0",
-                          "bundled": true
-                        },
-                        "is-redirect": {
-                          "version": "1.0.0",
-                          "bundled": true
-                        },
-                        "is-retry-allowed": {
-                          "version": "1.1.0",
-                          "bundled": true
-                        },
-                        "is-stream": {
-                          "version": "1.1.0",
-                          "bundled": true
-                        },
-                        "lowercase-keys": {
-                          "version": "1.0.0",
-                          "bundled": true
-                        },
-                        "timed-out": {
-                          "version": "4.0.1",
-                          "bundled": true
-                        },
-                        "unzip-response": {
-                          "version": "2.0.1",
-                          "bundled": true
-                        },
-                        "url-parse-lax": {
-                          "version": "1.0.0",
-                          "bundled": true,
-                          "requires": {
-                            "prepend-http": "^1.0.1"
-                          },
-                          "dependencies": {
-                            "prepend-http": {
-                              "version": "1.0.4",
-                              "bundled": true
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "registry-auth-token": {
-                      "version": "3.3.1",
-                      "bundled": true,
-                      "requires": {
-                        "rc": "^1.1.6",
-                        "safe-buffer": "^5.0.1"
-                      },
-                      "dependencies": {
-                        "rc": {
-                          "version": "1.2.1",
-                          "bundled": true,
-                          "requires": {
-                            "deep-extend": "~0.4.0",
-                            "ini": "~1.3.0",
-                            "minimist": "^1.2.0",
-                            "strip-json-comments": "~2.0.1"
-                          },
-                          "dependencies": {
-                            "deep-extend": {
-                              "version": "0.4.2",
-                              "bundled": true
-                            },
-                            "minimist": {
-                              "version": "1.2.0",
-                              "bundled": true
-                            },
-                            "strip-json-comments": {
-                              "version": "2.0.1",
-                              "bundled": true
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "registry-url": {
-                      "version": "3.1.0",
-                      "bundled": true,
-                      "requires": {
-                        "rc": "^1.0.1"
-                      },
-                      "dependencies": {
-                        "rc": {
-                          "version": "1.2.1",
-                          "bundled": true,
-                          "requires": {
-                            "deep-extend": "~0.4.0",
-                            "ini": "~1.3.0",
-                            "minimist": "^1.2.0",
-                            "strip-json-comments": "~2.0.1"
-                          },
-                          "dependencies": {
-                            "deep-extend": {
-                              "version": "0.4.2",
-                              "bundled": true
-                            },
-                            "minimist": {
-                              "version": "1.2.0",
-                              "bundled": true
-                            },
-                            "strip-json-comments": {
-                              "version": "2.0.1",
-                              "bundled": true
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            },
-            "semver-diff": {
-              "version": "2.1.0",
-              "bundled": true,
-              "requires": {
-                "semver": "^5.0.3"
-              }
-            },
-            "xdg-basedir": {
-              "version": "3.0.0",
-              "bundled": true
-            }
-          }
-        },
-        "uuid": {
-          "version": "3.1.0",
-          "bundled": true
-        },
-        "validate-npm-package-license": {
-          "version": "3.0.1",
-          "bundled": true,
-          "requires": {
-            "spdx-correct": "~1.0.0",
-            "spdx-expression-parse": "~1.0.0"
-          },
-          "dependencies": {
-            "spdx-correct": {
-              "version": "1.0.2",
-              "bundled": true,
-              "requires": {
-                "spdx-license-ids": "^1.0.2"
-              },
-              "dependencies": {
-                "spdx-license-ids": {
-                  "version": "1.2.2",
-                  "bundled": true
-                }
-              }
-            },
-            "spdx-expression-parse": {
-              "version": "1.0.4",
-              "bundled": true
-            }
-          }
-        },
-        "validate-npm-package-name": {
-          "version": "3.0.0",
-          "bundled": true,
-          "requires": {
-            "builtins": "^1.0.3"
-          },
-          "dependencies": {
-            "builtins": {
-              "version": "1.0.3",
-              "bundled": true
-            }
-          }
-        },
-        "which": {
-          "version": "1.2.14",
-          "bundled": true,
-          "requires": {
-            "isexe": "^2.0.0"
-          },
-          "dependencies": {
-            "isexe": {
-              "version": "2.0.0",
-              "bundled": true
-            }
-          }
-        },
-        "worker-farm": {
-          "version": "1.3.1",
-          "bundled": true,
-          "requires": {
-            "errno": ">=0.1.1 <0.2.0-0",
-            "xtend": ">=4.0.0 <4.1.0-0"
-          },
-          "dependencies": {
-            "errno": {
-              "version": "0.1.4",
-              "bundled": true,
-              "requires": {
-                "prr": "~0.0.0"
-              },
-              "dependencies": {
-                "prr": {
-                  "version": "0.0.0",
-                  "bundled": true
-                }
-              }
-            },
-            "xtend": {
-              "version": "4.0.1",
-              "bundled": true
-            }
-          }
-        },
-        "wrappy": {
-          "version": "1.0.2",
-          "bundled": true
-        },
-        "write-file-atomic": {
-          "version": "2.1.0",
-          "bundled": true,
-          "requires": {
-            "graceful-fs": "^4.1.11",
-            "imurmurhash": "^0.1.4",
-            "slide": "^1.1.5"
-          }
-        }
-      }
+    "normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA=="
     },
-    "npmi": {
+    "npm-normalize-package-bin": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/npmi/-/npmi-1.0.1.tgz",
-      "integrity": "sha1-FddpJzVHVF5oCdzwzhiu1IsCkOI=",
-      "requires": {
-        "npm": "^2.1.12",
-        "semver": "^4.1.0"
-      },
-      "dependencies": {
-        "npm": {
-          "version": "2.15.12",
-          "resolved": "https://registry.npmjs.org/npm/-/npm-2.15.12.tgz",
-          "integrity": "sha1-33w+1aJ3w/nUtdgZsFMR0QogCuY=",
-          "requires": {
-            "abbrev": "~1.0.9",
-            "ansi": "~0.3.1",
-            "ansi-regex": "*",
-            "ansicolors": "~0.3.2",
-            "ansistyles": "~0.1.3",
-            "archy": "~1.0.0",
-            "async-some": "~1.0.2",
-            "block-stream": "0.0.9",
-            "char-spinner": "~1.0.1",
-            "chmodr": "~1.0.2",
-            "chownr": "~1.0.1",
-            "cmd-shim": "~2.0.2",
-            "columnify": "~1.5.4",
-            "config-chain": "~1.1.10",
-            "dezalgo": "~1.0.3",
-            "editor": "~1.0.0",
-            "fs-vacuum": "~1.2.9",
-            "fs-write-stream-atomic": "~1.0.8",
-            "fstream": "~1.0.10",
-            "fstream-npm": "~1.1.1",
-            "github-url-from-git": "~1.4.0",
-            "github-url-from-username-repo": "~1.0.2",
-            "glob": "~7.0.6",
-            "graceful-fs": "~4.1.6",
-            "hosted-git-info": "~2.1.5",
-            "imurmurhash": "*",
-            "inflight": "~1.0.4",
-            "inherits": "~2.0.3",
-            "ini": "~1.3.4",
-            "init-package-json": "~1.9.4",
-            "lockfile": "~1.0.1",
-            "lru-cache": "~4.0.1",
-            "minimatch": "~3.0.3",
-            "mkdirp": "~0.5.1",
-            "node-gyp": "~3.6.0",
-            "nopt": "~3.0.6",
-            "normalize-git-url": "~3.0.2",
-            "normalize-package-data": "~2.3.5",
-            "npm-cache-filename": "~1.0.2",
-            "npm-install-checks": "~1.0.7",
-            "npm-package-arg": "~4.1.0",
-            "npm-registry-client": "~7.2.1",
-            "npm-user-validate": "~0.1.5",
-            "npmlog": "~2.0.4",
-            "once": "~1.4.0",
-            "opener": "~1.4.1",
-            "osenv": "~0.1.3",
-            "path-is-inside": "~1.0.0",
-            "read": "~1.0.7",
-            "read-installed": "~4.0.3",
-            "read-package-json": "~2.0.4",
-            "readable-stream": "~2.1.5",
-            "realize-package-specifier": "~3.0.1",
-            "request": "~2.74.0",
-            "retry": "~0.10.0",
-            "rimraf": "~2.5.4",
-            "semver": "~5.1.0",
-            "sha": "~2.0.1",
-            "slide": "~1.1.6",
-            "sorted-object": "~2.0.0",
-            "spdx-license-ids": "~1.2.2",
-            "strip-ansi": "~3.0.1",
-            "tar": "~2.2.1",
-            "text-table": "~0.2.0",
-            "uid-number": "0.0.6",
-            "umask": "~1.1.0",
-            "validate-npm-package-license": "~3.0.1",
-            "validate-npm-package-name": "~2.2.2",
-            "which": "~1.2.11",
-            "wrappy": "~1.0.2",
-            "write-file-atomic": "~1.1.4"
-          },
-          "dependencies": {
-            "abbrev": {
-              "version": "1.0.9",
-              "bundled": true
-            },
-            "ansi": {
-              "version": "0.3.1",
-              "bundled": true
-            },
-            "ansi-regex": {
-              "version": "2.0.0",
-              "bundled": true
-            },
-            "ansicolors": {
-              "version": "0.3.2",
-              "bundled": true
-            },
-            "ansistyles": {
-              "version": "0.1.3",
-              "bundled": true
-            },
-            "archy": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "async-some": {
-              "version": "1.0.2",
-              "bundled": true,
-              "requires": {
-                "dezalgo": "^1.0.2"
-              }
-            },
-            "block-stream": {
-              "version": "0.0.9",
-              "bundled": true,
-              "requires": {
-                "inherits": "~2.0.0"
-              }
-            },
-            "char-spinner": {
-              "version": "1.0.1",
-              "bundled": true
-            },
-            "chmodr": {
-              "version": "1.0.2",
-              "bundled": true
-            },
-            "chownr": {
-              "version": "1.0.1",
-              "bundled": true
-            },
-            "cmd-shim": {
-              "version": "2.0.2",
-              "bundled": true,
-              "requires": {
-                "graceful-fs": "^4.1.2",
-                "mkdirp": "~0.5.0"
-              }
-            },
-            "columnify": {
-              "version": "1.5.4",
-              "bundled": true,
-              "requires": {
-                "strip-ansi": "^3.0.0",
-                "wcwidth": "^1.0.0"
-              },
-              "dependencies": {
-                "wcwidth": {
-                  "version": "1.0.0",
-                  "bundled": true,
-                  "requires": {
-                    "defaults": "^1.0.0"
-                  },
-                  "dependencies": {
-                    "defaults": {
-                      "version": "1.0.3",
-                      "bundled": true,
-                      "requires": {
-                        "clone": "^1.0.2"
-                      },
-                      "dependencies": {
-                        "clone": {
-                          "version": "1.0.2",
-                          "bundled": true
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            },
-            "config-chain": {
-              "version": "1.1.10",
-              "bundled": true,
-              "requires": {
-                "ini": "^1.3.4",
-                "proto-list": "~1.2.1"
-              },
-              "dependencies": {
-                "proto-list": {
-                  "version": "1.2.4",
-                  "bundled": true
-                }
-              }
-            },
-            "dezalgo": {
-              "version": "1.0.3",
-              "bundled": true,
-              "requires": {
-                "asap": "^2.0.0",
-                "wrappy": "1"
-              },
-              "dependencies": {
-                "asap": {
-                  "version": "2.0.3",
-                  "bundled": true
-                }
-              }
-            },
-            "editor": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "fs-vacuum": {
-              "version": "1.2.9",
-              "bundled": true,
-              "requires": {
-                "graceful-fs": "^4.1.2",
-                "path-is-inside": "^1.0.1",
-                "rimraf": "^2.5.2"
-              }
-            },
-            "fs-write-stream-atomic": {
-              "version": "1.0.8",
-              "bundled": true,
-              "requires": {
-                "graceful-fs": "^4.1.2",
-                "iferr": "^0.1.5",
-                "imurmurhash": "^0.1.4",
-                "readable-stream": "1 || 2"
-              },
-              "dependencies": {
-                "iferr": {
-                  "version": "0.1.5",
-                  "bundled": true
-                }
-              }
-            },
-            "fstream": {
-              "version": "1.0.10",
-              "bundled": true,
-              "requires": {
-                "graceful-fs": "^4.1.2",
-                "inherits": "~2.0.0",
-                "mkdirp": ">=0.5 0",
-                "rimraf": "2"
-              }
-            },
-            "fstream-npm": {
-              "version": "1.1.1",
-              "bundled": true,
-              "requires": {
-                "fstream-ignore": "^1.0.0",
-                "inherits": "2"
-              },
-              "dependencies": {
-                "fstream-ignore": {
-                  "version": "1.0.5",
-                  "bundled": true,
-                  "requires": {
-                    "fstream": "^1.0.0",
-                    "inherits": "2",
-                    "minimatch": "^3.0.0"
-                  }
-                }
-              }
-            },
-            "github-url-from-git": {
-              "version": "1.4.0",
-              "bundled": true
-            },
-            "github-url-from-username-repo": {
-              "version": "1.0.2",
-              "bundled": true
-            },
-            "glob": {
-              "version": "7.0.6",
-              "bundled": true,
-              "requires": {
-                "fs.realpath": "^1.0.0",
-                "inflight": "^1.0.4",
-                "inherits": "2",
-                "minimatch": "^3.0.2",
-                "once": "^1.3.0",
-                "path-is-absolute": "^1.0.0"
-              },
-              "dependencies": {
-                "fs.realpath": {
-                  "version": "1.0.0",
-                  "bundled": true
-                },
-                "path-is-absolute": {
-                  "version": "1.0.0",
-                  "bundled": true
-                }
-              }
-            },
-            "graceful-fs": {
-              "version": "4.1.6",
-              "bundled": true
-            },
-            "hosted-git-info": {
-              "version": "2.1.5",
-              "bundled": true
-            },
-            "imurmurhash": {
-              "version": "0.1.4",
-              "bundled": true
-            },
-            "inflight": {
-              "version": "1.0.5",
-              "bundled": true,
-              "requires": {
-                "once": "^1.3.0",
-                "wrappy": "1"
-              }
-            },
-            "inherits": {
-              "version": "2.0.3",
-              "bundled": true
-            },
-            "ini": {
-              "version": "1.3.4",
-              "bundled": true
-            },
-            "init-package-json": {
-              "version": "1.9.4",
-              "bundled": true,
-              "requires": {
-                "glob": "^6.0.0",
-                "npm-package-arg": "^4.0.0",
-                "promzard": "^0.3.0",
-                "read": "~1.0.1",
-                "read-package-json": "1 || 2",
-                "semver": "2.x || 3.x || 4 || 5",
-                "validate-npm-package-license": "^3.0.1",
-                "validate-npm-package-name": "^2.0.1"
-              },
-              "dependencies": {
-                "glob": {
-                  "version": "6.0.4",
-                  "bundled": true,
-                  "requires": {
-                    "inflight": "^1.0.4",
-                    "inherits": "2",
-                    "minimatch": "2 || 3",
-                    "once": "^1.3.0",
-                    "path-is-absolute": "^1.0.0"
-                  },
-                  "dependencies": {
-                    "path-is-absolute": {
-                      "version": "1.0.0",
-                      "bundled": true
-                    }
-                  }
-                },
-                "promzard": {
-                  "version": "0.3.0",
-                  "bundled": true,
-                  "requires": {
-                    "read": "1"
-                  }
-                }
-              }
-            },
-            "lockfile": {
-              "version": "1.0.1",
-              "bundled": true
-            },
-            "lru-cache": {
-              "version": "4.0.1",
-              "bundled": true,
-              "requires": {
-                "pseudomap": "^1.0.1",
-                "yallist": "^2.0.0"
-              },
-              "dependencies": {
-                "pseudomap": {
-                  "version": "1.0.2",
-                  "bundled": true
-                },
-                "yallist": {
-                  "version": "2.0.0",
-                  "bundled": true
-                }
-              }
-            },
-            "minimatch": {
-              "version": "3.0.3",
-              "bundled": true,
-              "requires": {
-                "brace-expansion": "^1.0.0"
-              },
-              "dependencies": {
-                "brace-expansion": {
-                  "version": "1.1.6",
-                  "bundled": true,
-                  "requires": {
-                    "balanced-match": "^0.4.1",
-                    "concat-map": "0.0.1"
-                  },
-                  "dependencies": {
-                    "balanced-match": {
-                      "version": "0.4.2",
-                      "bundled": true
-                    },
-                    "concat-map": {
-                      "version": "0.0.1",
-                      "bundled": true
-                    }
-                  }
-                }
-              }
-            },
-            "mkdirp": {
-              "version": "0.5.1",
-              "bundled": true,
-              "requires": {
-                "minimist": "0.0.8"
-              },
-              "dependencies": {
-                "minimist": {
-                  "version": "0.0.8",
-                  "bundled": true
-                }
-              }
-            },
-            "node-gyp": {
-              "version": "3.6.0",
-              "bundled": true,
-              "requires": {
-                "fstream": "^1.0.0",
-                "glob": "^7.0.3",
-                "graceful-fs": "^4.1.2",
-                "minimatch": "^3.0.2",
-                "mkdirp": "^0.5.0",
-                "nopt": "2 || 3",
-                "npmlog": "0 || 1 || 2 || 3 || 4",
-                "osenv": "0",
-                "request": "2",
-                "rimraf": "2",
-                "semver": "~5.3.0",
-                "tar": "^2.0.0",
-                "which": "1"
-              },
-              "dependencies": {
-                "semver": {
-                  "version": "5.3.0",
-                  "bundled": true
-                }
-              }
-            },
-            "nopt": {
-              "version": "3.0.6",
-              "bundled": true,
-              "requires": {
-                "abbrev": "1"
-              }
-            },
-            "normalize-git-url": {
-              "version": "3.0.2",
-              "bundled": true
-            },
-            "normalize-package-data": {
-              "version": "2.3.5",
-              "bundled": true,
-              "requires": {
-                "hosted-git-info": "^2.1.4",
-                "is-builtin-module": "^1.0.0",
-                "semver": "2 || 3 || 4 || 5",
-                "validate-npm-package-license": "^3.0.1"
-              },
-              "dependencies": {
-                "is-builtin-module": {
-                  "version": "1.0.0",
-                  "bundled": true,
-                  "requires": {
-                    "builtin-modules": "^1.0.0"
-                  },
-                  "dependencies": {
-                    "builtin-modules": {
-                      "version": "1.1.0",
-                      "bundled": true
-                    }
-                  }
-                }
-              }
-            },
-            "npm-cache-filename": {
-              "version": "1.0.2",
-              "bundled": true
-            },
-            "npm-install-checks": {
-              "version": "1.0.7",
-              "bundled": true,
-              "requires": {
-                "npmlog": "0.1 || 1 || 2",
-                "semver": "^2.3.0 || 3.x || 4 || 5"
-              }
-            },
-            "npm-package-arg": {
-              "version": "4.1.0",
-              "bundled": true,
-              "requires": {
-                "hosted-git-info": "^2.1.4",
-                "semver": "4 || 5"
-              }
-            },
-            "npm-registry-client": {
-              "version": "7.2.1",
-              "bundled": true,
-              "requires": {
-                "concat-stream": "^1.5.2",
-                "graceful-fs": "^4.1.6",
-                "normalize-package-data": "~1.0.1 || ^2.0.0",
-                "npm-package-arg": "^3.0.0 || ^4.0.0",
-                "npmlog": "~2.0.0 || ~3.1.0",
-                "once": "^1.3.3",
-                "request": "^2.74.0",
-                "retry": "^0.10.0",
-                "semver": "2 >=2.2.1 || 3.x || 4 || 5",
-                "slide": "^1.1.3"
-              },
-              "dependencies": {
-                "concat-stream": {
-                  "version": "1.5.2",
-                  "bundled": true,
-                  "requires": {
-                    "inherits": "~2.0.1",
-                    "readable-stream": "~2.0.0",
-                    "typedarray": "~0.0.5"
-                  },
-                  "dependencies": {
-                    "readable-stream": {
-                      "version": "2.0.6",
-                      "bundled": true,
-                      "requires": {
-                        "core-util-is": "~1.0.0",
-                        "inherits": "~2.0.1",
-                        "isarray": "~1.0.0",
-                        "process-nextick-args": "~1.0.6",
-                        "string_decoder": "~0.10.x",
-                        "util-deprecate": "~1.0.1"
-                      },
-                      "dependencies": {
-                        "core-util-is": {
-                          "version": "1.0.2",
-                          "bundled": true
-                        },
-                        "isarray": {
-                          "version": "1.0.0",
-                          "bundled": true
-                        },
-                        "process-nextick-args": {
-                          "version": "1.0.7",
-                          "bundled": true
-                        },
-                        "string_decoder": {
-                          "version": "0.10.31",
-                          "bundled": true
-                        },
-                        "util-deprecate": {
-                          "version": "1.0.2",
-                          "bundled": true
-                        }
-                      }
-                    },
-                    "typedarray": {
-                      "version": "0.0.6",
-                      "bundled": true
-                    }
-                  }
-                },
-                "retry": {
-                  "version": "0.10.0",
-                  "bundled": true
-                }
-              }
-            },
-            "npm-user-validate": {
-              "version": "0.1.5",
-              "bundled": true
-            },
-            "npmlog": {
-              "version": "2.0.4",
-              "bundled": true,
-              "requires": {
-                "ansi": "~0.3.1",
-                "are-we-there-yet": "~1.1.2",
-                "gauge": "~1.2.5"
-              },
-              "dependencies": {
-                "are-we-there-yet": {
-                  "version": "1.1.2",
-                  "bundled": true,
-                  "requires": {
-                    "delegates": "^1.0.0",
-                    "readable-stream": "^2.0.0 || ^1.1.13"
-                  },
-                  "dependencies": {
-                    "delegates": {
-                      "version": "1.0.0",
-                      "bundled": true
-                    }
-                  }
-                },
-                "gauge": {
-                  "version": "1.2.7",
-                  "bundled": true,
-                  "requires": {
-                    "ansi": "^0.3.0",
-                    "has-unicode": "^2.0.0",
-                    "lodash.pad": "^4.1.0",
-                    "lodash.padend": "^4.1.0",
-                    "lodash.padstart": "^4.1.0"
-                  },
-                  "dependencies": {
-                    "has-unicode": {
-                      "version": "2.0.0",
-                      "bundled": true
-                    },
-                    "lodash._baseslice": {
-                      "version": "4.0.0",
-                      "bundled": true
-                    },
-                    "lodash._basetostring": {
-                      "version": "4.12.0",
-                      "bundled": true
-                    },
-                    "lodash.pad": {
-                      "version": "4.4.0",
-                      "bundled": true,
-                      "requires": {
-                        "lodash._baseslice": "~4.0.0",
-                        "lodash._basetostring": "~4.12.0",
-                        "lodash.tostring": "^4.0.0"
-                      }
-                    },
-                    "lodash.padend": {
-                      "version": "4.5.0",
-                      "bundled": true,
-                      "requires": {
-                        "lodash._baseslice": "~4.0.0",
-                        "lodash._basetostring": "~4.12.0",
-                        "lodash.tostring": "^4.0.0"
-                      }
-                    },
-                    "lodash.padstart": {
-                      "version": "4.5.0",
-                      "bundled": true,
-                      "requires": {
-                        "lodash._baseslice": "~4.0.0",
-                        "lodash._basetostring": "~4.12.0",
-                        "lodash.tostring": "^4.0.0"
-                      }
-                    },
-                    "lodash.tostring": {
-                      "version": "4.1.4",
-                      "bundled": true
-                    }
-                  }
-                }
-              }
-            },
-            "once": {
-              "version": "1.4.0",
-              "bundled": true,
-              "requires": {
-                "wrappy": "1"
-              }
-            },
-            "opener": {
-              "version": "1.4.1",
-              "bundled": true
-            },
-            "osenv": {
-              "version": "0.1.3",
-              "bundled": true,
-              "requires": {
-                "os-homedir": "^1.0.0",
-                "os-tmpdir": "^1.0.0"
-              },
-              "dependencies": {
-                "os-homedir": {
-                  "version": "1.0.0",
-                  "bundled": true
-                },
-                "os-tmpdir": {
-                  "version": "1.0.1",
-                  "bundled": true
-                }
-              }
-            },
-            "path-is-inside": {
-              "version": "1.0.1",
-              "bundled": true
-            },
-            "read": {
-              "version": "1.0.7",
-              "bundled": true,
-              "requires": {
-                "mute-stream": "~0.0.4"
-              },
-              "dependencies": {
-                "mute-stream": {
-                  "version": "0.0.5",
-                  "bundled": true
-                }
-              }
-            },
-            "read-installed": {
-              "version": "4.0.3",
-              "bundled": true,
-              "requires": {
-                "debuglog": "^1.0.1",
-                "graceful-fs": "^4.1.2",
-                "read-package-json": "^2.0.0",
-                "readdir-scoped-modules": "^1.0.0",
-                "semver": "2 || 3 || 4 || 5",
-                "slide": "~1.1.3",
-                "util-extend": "^1.0.1"
-              },
-              "dependencies": {
-                "debuglog": {
-                  "version": "1.0.1",
-                  "bundled": true
-                },
-                "readdir-scoped-modules": {
-                  "version": "1.0.2",
-                  "bundled": true,
-                  "requires": {
-                    "debuglog": "^1.0.1",
-                    "dezalgo": "^1.0.0",
-                    "graceful-fs": "^4.1.2",
-                    "once": "^1.3.0"
-                  }
-                },
-                "util-extend": {
-                  "version": "1.0.1",
-                  "bundled": true
-                }
-              }
-            },
-            "read-package-json": {
-              "version": "2.0.4",
-              "bundled": true,
-              "requires": {
-                "glob": "^6.0.0",
-                "graceful-fs": "^4.1.2",
-                "json-parse-helpfulerror": "^1.0.2",
-                "normalize-package-data": "^2.0.0"
-              },
-              "dependencies": {
-                "glob": {
-                  "version": "6.0.4",
-                  "bundled": true,
-                  "requires": {
-                    "inflight": "^1.0.4",
-                    "inherits": "2",
-                    "minimatch": "2 || 3",
-                    "once": "^1.3.0",
-                    "path-is-absolute": "^1.0.0"
-                  },
-                  "dependencies": {
-                    "path-is-absolute": {
-                      "version": "1.0.0",
-                      "bundled": true
-                    }
-                  }
-                },
-                "json-parse-helpfulerror": {
-                  "version": "1.0.3",
-                  "bundled": true,
-                  "requires": {
-                    "jju": "^1.1.0"
-                  },
-                  "dependencies": {
-                    "jju": {
-                      "version": "1.3.0",
-                      "bundled": true
-                    }
-                  }
-                }
-              }
-            },
-            "readable-stream": {
-              "version": "2.1.5",
-              "bundled": true,
-              "requires": {
-                "buffer-shims": "^1.0.0",
-                "core-util-is": "~1.0.0",
-                "inherits": "~2.0.1",
-                "isarray": "~1.0.0",
-                "process-nextick-args": "~1.0.6",
-                "string_decoder": "~0.10.x",
-                "util-deprecate": "~1.0.1"
-              },
-              "dependencies": {
-                "buffer-shims": {
-                  "version": "1.0.0",
-                  "bundled": true
-                },
-                "core-util-is": {
-                  "version": "1.0.2",
-                  "bundled": true
-                },
-                "isarray": {
-                  "version": "1.0.0",
-                  "bundled": true
-                },
-                "process-nextick-args": {
-                  "version": "1.0.7",
-                  "bundled": true
-                },
-                "string_decoder": {
-                  "version": "0.10.31",
-                  "bundled": true
-                },
-                "util-deprecate": {
-                  "version": "1.0.2",
-                  "bundled": true
-                }
-              }
-            },
-            "realize-package-specifier": {
-              "version": "3.0.1",
-              "bundled": true,
-              "requires": {
-                "dezalgo": "^1.0.1",
-                "npm-package-arg": "^4.0.0"
-              }
-            },
-            "request": {
-              "version": "2.74.0",
-              "bundled": true,
-              "requires": {
-                "aws-sign2": "~0.6.0",
-                "aws4": "^1.2.1",
-                "bl": "~1.1.2",
-                "caseless": "~0.11.0",
-                "combined-stream": "~1.0.5",
-                "extend": "~3.0.0",
-                "forever-agent": "~0.6.1",
-                "form-data": "~1.0.0-rc4",
-                "har-validator": "~2.0.6",
-                "hawk": "~3.1.3",
-                "http-signature": "~1.1.0",
-                "is-typedarray": "~1.0.0",
-                "isstream": "~0.1.2",
-                "json-stringify-safe": "~5.0.1",
-                "mime-types": "~2.1.7",
-                "node-uuid": "~1.4.7",
-                "oauth-sign": "~0.8.1",
-                "qs": "~6.2.0",
-                "stringstream": "~0.0.4",
-                "tough-cookie": "~2.3.0",
-                "tunnel-agent": "~0.4.1"
-              },
-              "dependencies": {
-                "aws-sign2": {
-                  "version": "0.6.0",
-                  "bundled": true
-                },
-                "aws4": {
-                  "version": "1.4.1",
-                  "bundled": true
-                },
-                "bl": {
-                  "version": "1.1.2",
-                  "bundled": true,
-                  "requires": {
-                    "readable-stream": "~2.0.5"
-                  },
-                  "dependencies": {
-                    "readable-stream": {
-                      "version": "2.0.6",
-                      "bundled": true,
-                      "requires": {
-                        "core-util-is": "~1.0.0",
-                        "inherits": "~2.0.1",
-                        "isarray": "~1.0.0",
-                        "process-nextick-args": "~1.0.6",
-                        "string_decoder": "~0.10.x",
-                        "util-deprecate": "~1.0.1"
-                      },
-                      "dependencies": {
-                        "core-util-is": {
-                          "version": "1.0.2",
-                          "bundled": true
-                        },
-                        "isarray": {
-                          "version": "1.0.0",
-                          "bundled": true
-                        },
-                        "process-nextick-args": {
-                          "version": "1.0.7",
-                          "bundled": true
-                        },
-                        "string_decoder": {
-                          "version": "0.10.31",
-                          "bundled": true
-                        },
-                        "util-deprecate": {
-                          "version": "1.0.2",
-                          "bundled": true
-                        }
-                      }
-                    }
-                  }
-                },
-                "caseless": {
-                  "version": "0.11.0",
-                  "bundled": true
-                },
-                "combined-stream": {
-                  "version": "1.0.5",
-                  "bundled": true,
-                  "requires": {
-                    "delayed-stream": "~1.0.0"
-                  },
-                  "dependencies": {
-                    "delayed-stream": {
-                      "version": "1.0.0",
-                      "bundled": true
-                    }
-                  }
-                },
-                "extend": {
-                  "version": "3.0.0",
-                  "bundled": true
-                },
-                "forever-agent": {
-                  "version": "0.6.1",
-                  "bundled": true
-                },
-                "form-data": {
-                  "version": "1.0.0-rc4",
-                  "bundled": true,
-                  "requires": {
-                    "async": "^1.5.2",
-                    "combined-stream": "^1.0.5",
-                    "mime-types": "^2.1.10"
-                  },
-                  "dependencies": {
-                    "async": {
-                      "version": "1.5.2",
-                      "bundled": true
-                    }
-                  }
-                },
-                "har-validator": {
-                  "version": "2.0.6",
-                  "bundled": true,
-                  "requires": {
-                    "chalk": "^1.1.1",
-                    "commander": "^2.9.0",
-                    "is-my-json-valid": "^2.12.4",
-                    "pinkie-promise": "^2.0.0"
-                  },
-                  "dependencies": {
-                    "chalk": {
-                      "version": "1.1.3",
-                      "bundled": true,
-                      "requires": {
-                        "ansi-styles": "^2.2.1",
-                        "escape-string-regexp": "^1.0.2",
-                        "has-ansi": "^2.0.0",
-                        "strip-ansi": "^3.0.0",
-                        "supports-color": "^2.0.0"
-                      },
-                      "dependencies": {
-                        "ansi-styles": {
-                          "version": "2.2.1",
-                          "bundled": true
-                        },
-                        "escape-string-regexp": {
-                          "version": "1.0.5",
-                          "bundled": true
-                        },
-                        "has-ansi": {
-                          "version": "2.0.0",
-                          "bundled": true,
-                          "requires": {
-                            "ansi-regex": "^2.0.0"
-                          }
-                        },
-                        "supports-color": {
-                          "version": "2.0.0",
-                          "bundled": true
-                        }
-                      }
-                    },
-                    "commander": {
-                      "version": "2.9.0",
-                      "bundled": true,
-                      "requires": {
-                        "graceful-readlink": ">= 1.0.0"
-                      },
-                      "dependencies": {
-                        "graceful-readlink": {
-                          "version": "1.0.1",
-                          "bundled": true
-                        }
-                      }
-                    },
-                    "is-my-json-valid": {
-                      "version": "2.13.1",
-                      "bundled": true,
-                      "requires": {
-                        "generate-function": "^2.0.0",
-                        "generate-object-property": "^1.1.0",
-                        "jsonpointer": "2.0.0",
-                        "xtend": "^4.0.0"
-                      },
-                      "dependencies": {
-                        "generate-function": {
-                          "version": "2.0.0",
-                          "bundled": true
-                        },
-                        "generate-object-property": {
-                          "version": "1.2.0",
-                          "bundled": true,
-                          "requires": {
-                            "is-property": "^1.0.0"
-                          },
-                          "dependencies": {
-                            "is-property": {
-                              "version": "1.0.2",
-                              "bundled": true
-                            }
-                          }
-                        },
-                        "jsonpointer": {
-                          "version": "2.0.0",
-                          "bundled": true
-                        },
-                        "xtend": {
-                          "version": "4.0.1",
-                          "bundled": true
-                        }
-                      }
-                    },
-                    "pinkie-promise": {
-                      "version": "2.0.1",
-                      "bundled": true,
-                      "requires": {
-                        "pinkie": "^2.0.0"
-                      },
-                      "dependencies": {
-                        "pinkie": {
-                          "version": "2.0.4",
-                          "bundled": true
-                        }
-                      }
-                    }
-                  }
-                },
-                "hawk": {
-                  "version": "3.1.3",
-                  "bundled": true,
-                  "requires": {
-                    "boom": "2.x.x",
-                    "cryptiles": "2.x.x",
-                    "hoek": "2.x.x",
-                    "sntp": "1.x.x"
-                  },
-                  "dependencies": {
-                    "boom": {
-                      "version": "2.10.1",
-                      "bundled": true,
-                      "requires": {
-                        "hoek": "2.x.x"
-                      }
-                    },
-                    "cryptiles": {
-                      "version": "2.0.5",
-                      "bundled": true,
-                      "requires": {
-                        "boom": "2.x.x"
-                      }
-                    },
-                    "hoek": {
-                      "version": "2.16.3",
-                      "bundled": true
-                    },
-                    "sntp": {
-                      "version": "1.0.9",
-                      "bundled": true,
-                      "requires": {
-                        "hoek": "2.x.x"
-                      }
-                    }
-                  }
-                },
-                "http-signature": {
-                  "version": "1.1.1",
-                  "bundled": true,
-                  "requires": {
-                    "assert-plus": "^0.2.0",
-                    "jsprim": "^1.2.2",
-                    "sshpk": "^1.7.0"
-                  },
-                  "dependencies": {
-                    "assert-plus": {
-                      "version": "0.2.0",
-                      "bundled": true
-                    },
-                    "jsprim": {
-                      "version": "1.3.0",
-                      "bundled": true,
-                      "requires": {
-                        "extsprintf": "1.0.2",
-                        "json-schema": "0.2.2",
-                        "verror": "1.3.6"
-                      },
-                      "dependencies": {
-                        "extsprintf": {
-                          "version": "1.0.2",
-                          "bundled": true
-                        },
-                        "json-schema": {
-                          "version": "0.2.2",
-                          "bundled": true
-                        },
-                        "verror": {
-                          "version": "1.3.6",
-                          "bundled": true,
-                          "requires": {
-                            "extsprintf": "1.0.2"
-                          }
-                        }
-                      }
-                    },
-                    "sshpk": {
-                      "version": "1.9.2",
-                      "bundled": true,
-                      "requires": {
-                        "asn1": "~0.2.3",
-                        "assert-plus": "^1.0.0",
-                        "dashdash": "^1.12.0",
-                        "ecc-jsbn": "~0.1.1",
-                        "getpass": "^0.1.1",
-                        "jodid25519": "^1.0.0",
-                        "jsbn": "~0.1.0",
-                        "tweetnacl": "~0.13.0"
-                      },
-                      "dependencies": {
-                        "asn1": {
-                          "version": "0.2.3",
-                          "bundled": true
-                        },
-                        "assert-plus": {
-                          "version": "1.0.0",
-                          "bundled": true
-                        },
-                        "dashdash": {
-                          "version": "1.14.0",
-                          "bundled": true,
-                          "requires": {
-                            "assert-plus": "^1.0.0"
-                          }
-                        },
-                        "ecc-jsbn": {
-                          "version": "0.1.1",
-                          "bundled": true,
-                          "optional": true,
-                          "requires": {
-                            "jsbn": "~0.1.0"
-                          }
-                        },
-                        "getpass": {
-                          "version": "0.1.6",
-                          "bundled": true,
-                          "requires": {
-                            "assert-plus": "^1.0.0"
-                          }
-                        },
-                        "jodid25519": {
-                          "version": "1.0.2",
-                          "bundled": true,
-                          "optional": true,
-                          "requires": {
-                            "jsbn": "~0.1.0"
-                          }
-                        },
-                        "jsbn": {
-                          "version": "0.1.0",
-                          "bundled": true,
-                          "optional": true
-                        },
-                        "tweetnacl": {
-                          "version": "0.13.3",
-                          "bundled": true,
-                          "optional": true
-                        }
-                      }
-                    }
-                  }
-                },
-                "is-typedarray": {
-                  "version": "1.0.0",
-                  "bundled": true
-                },
-                "isstream": {
-                  "version": "0.1.2",
-                  "bundled": true
-                },
-                "json-stringify-safe": {
-                  "version": "5.0.1",
-                  "bundled": true
-                },
-                "mime-types": {
-                  "version": "2.1.11",
-                  "bundled": true,
-                  "requires": {
-                    "mime-db": "~1.23.0"
-                  },
-                  "dependencies": {
-                    "mime-db": {
-                      "version": "1.23.0",
-                      "bundled": true
-                    }
-                  }
-                },
-                "node-uuid": {
-                  "version": "1.4.7",
-                  "bundled": true
-                },
-                "oauth-sign": {
-                  "version": "0.8.2",
-                  "bundled": true
-                },
-                "qs": {
-                  "version": "6.2.1",
-                  "bundled": true
-                },
-                "stringstream": {
-                  "version": "0.0.5",
-                  "bundled": true
-                },
-                "tough-cookie": {
-                  "version": "2.3.1",
-                  "bundled": true
-                },
-                "tunnel-agent": {
-                  "version": "0.4.3",
-                  "bundled": true
-                }
-              }
-            },
-            "retry": {
-              "version": "0.10.0",
-              "bundled": true
-            },
-            "rimraf": {
-              "version": "2.5.4",
-              "bundled": true,
-              "requires": {
-                "glob": "^7.0.5"
-              }
-            },
-            "semver": {
-              "version": "5.1.0",
-              "bundled": true
-            },
-            "sha": {
-              "version": "2.0.1",
-              "bundled": true,
-              "requires": {
-                "graceful-fs": "^4.1.2",
-                "readable-stream": "^2.0.2"
-              },
-              "dependencies": {
-                "readable-stream": {
-                  "version": "2.0.2",
-                  "bundled": true,
-                  "requires": {
-                    "core-util-is": "~1.0.0",
-                    "inherits": "~2.0.1",
-                    "isarray": "0.0.1",
-                    "process-nextick-args": "~1.0.0",
-                    "string_decoder": "~0.10.x",
-                    "util-deprecate": "~1.0.1"
-                  },
-                  "dependencies": {
-                    "core-util-is": {
-                      "version": "1.0.1",
-                      "bundled": true
-                    },
-                    "isarray": {
-                      "version": "0.0.1",
-                      "bundled": true
-                    },
-                    "process-nextick-args": {
-                      "version": "1.0.3",
-                      "bundled": true
-                    },
-                    "string_decoder": {
-                      "version": "0.10.31",
-                      "bundled": true
-                    },
-                    "util-deprecate": {
-                      "version": "1.0.1",
-                      "bundled": true
-                    }
-                  }
-                }
-              }
-            },
-            "slide": {
-              "version": "1.1.6",
-              "bundled": true
-            },
-            "sorted-object": {
-              "version": "2.0.0",
-              "bundled": true
-            },
-            "spdx-license-ids": {
-              "version": "1.2.2",
-              "bundled": true
-            },
-            "strip-ansi": {
-              "version": "3.0.1",
-              "bundled": true,
-              "requires": {
-                "ansi-regex": "^2.0.0"
-              }
-            },
-            "tar": {
-              "version": "2.2.1",
-              "bundled": true,
-              "requires": {
-                "block-stream": "*",
-                "fstream": "^1.0.2",
-                "inherits": "2"
-              }
-            },
-            "text-table": {
-              "version": "0.2.0",
-              "bundled": true
-            },
-            "uid-number": {
-              "version": "0.0.6",
-              "bundled": true
-            },
-            "umask": {
-              "version": "1.1.0",
-              "bundled": true
-            },
-            "validate-npm-package-license": {
-              "version": "3.0.1",
-              "bundled": true,
-              "requires": {
-                "spdx-correct": "~1.0.0",
-                "spdx-expression-parse": "~1.0.0"
-              },
-              "dependencies": {
-                "spdx-correct": {
-                  "version": "1.0.2",
-                  "bundled": true,
-                  "requires": {
-                    "spdx-license-ids": "^1.0.2"
-                  }
-                },
-                "spdx-expression-parse": {
-                  "version": "1.0.2",
-                  "bundled": true,
-                  "requires": {
-                    "spdx-exceptions": "^1.0.4",
-                    "spdx-license-ids": "^1.0.0"
-                  },
-                  "dependencies": {
-                    "spdx-exceptions": {
-                      "version": "1.0.4",
-                      "bundled": true
-                    }
-                  }
-                }
-              }
-            },
-            "validate-npm-package-name": {
-              "version": "2.2.2",
-              "bundled": true,
-              "requires": {
-                "builtins": "0.0.7"
-              },
-              "dependencies": {
-                "builtins": {
-                  "version": "0.0.7",
-                  "bundled": true
-                }
-              }
-            },
-            "which": {
-              "version": "1.2.11",
-              "bundled": true,
-              "requires": {
-                "isexe": "^1.1.1"
-              },
-              "dependencies": {
-                "isexe": {
-                  "version": "1.1.2",
-                  "bundled": true
-                }
-              }
-            },
-            "wrappy": {
-              "version": "1.0.2",
-              "bundled": true
-            },
-            "write-file-atomic": {
-              "version": "1.1.4",
-              "bundled": true,
-              "requires": {
-                "graceful-fs": "^4.1.2",
-                "imurmurhash": "^0.1.4",
-                "slide": "^1.1.5"
-              }
-            }
-          }
-        },
-        "semver": {
-          "version": "4.3.6",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz",
-          "integrity": "sha1-MAvG4OhjdPe6YQaLWx7NV/xlMto="
-        }
-      }
+      "resolved": "https://registry.npmjs.org/npm-normalize-package-bin/-/npm-normalize-package-bin-1.0.1.tgz",
+      "integrity": "sha512-EPfafl6JL5/rU+ot6P3gRSCpPDW5VmIzX959Ob1+ySFUuuYHWHekXpwdUZcKP5C+DS4GEtdJluwBjnsNDl+fSA=="
     },
     "nth-check": {
       "version": "1.0.2",
@@ -5678,46 +2119,41 @@
         "boolbase": "~1.0.0"
       }
     },
+    "nunjucks": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/nunjucks/-/nunjucks-3.2.3.tgz",
+      "integrity": "sha512-psb6xjLj47+fE76JdZwskvwG4MYsQKXUtMsPh6U0YMvmyjRtKRFcxnlXGWglNybtNTNVmGdp94K62/+NjF5FDQ==",
+      "requires": {
+        "a-sync-waterfall": "^1.0.0",
+        "asap": "^2.0.3",
+        "commander": "^5.1.0"
+      }
+    },
+    "nunjucks-do": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/nunjucks-do/-/nunjucks-do-1.0.0.tgz",
+      "integrity": "sha1-UGu9S0LbKas9raQbRVVGuZB+8d8="
+    },
+    "nwmatcher": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/nwmatcher/-/nwmatcher-1.4.4.tgz",
+      "integrity": "sha512-3iuY4N5dhgMpCUrOVnuAdGrgxVqV2cJpM+XNccjR2DKOB1RUP0aA+wGXEiNziG/UKboFyGBIoKOaNlJxx8bciQ==",
+      "optional": true
+    },
+    "oauth-sign": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
+      "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ=="
+    },
     "object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
     },
-    "object-copy": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
-      "integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
-      "requires": {
-        "copy-descriptor": "^0.1.0",
-        "define-property": "^0.2.5",
-        "kind-of": "^3.0.3"
-      },
-      "dependencies": {
-        "define-property": {
-          "version": "0.2.5",
-          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
-          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-          "requires": {
-            "is-descriptor": "^0.1.0"
-          }
-        },
-        "kind-of": {
-          "version": "3.2.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-          "requires": {
-            "is-buffer": "^1.1.5"
-          }
-        }
-      }
-    },
-    "object-visit": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
-      "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
-      "requires": {
-        "isobject": "^3.0.0"
-      }
+    "object-path": {
+      "version": "0.11.8",
+      "resolved": "https://registry.npmjs.org/object-path/-/object-path-0.11.8.tgz",
+      "integrity": "sha512-YJjNZrlXJFM42wTBn6zgOJVar9KFJvzx6sTWDte8sWZF//cnjl0BxHNpfZx+ZffXX63A9q0b1zsFiBX4g4X5KA=="
     },
     "object.defaults": {
       "version": "1.1.0",
@@ -5728,6 +2164,13 @@
         "array-slice": "^1.0.0",
         "for-own": "^1.0.0",
         "isobject": "^3.0.0"
+      },
+      "dependencies": {
+        "isobject": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+        }
       }
     },
     "object.map": {
@@ -5745,6 +2188,30 @@
       "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
       "requires": {
         "isobject": "^3.0.1"
+      },
+      "dependencies": {
+        "isobject": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+        }
+      }
+    },
+    "omit-keys": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/omit-keys/-/omit-keys-0.1.0.tgz",
+      "integrity": "sha1-4U7FygnNSuB/w56Mo1k5c4RJvsg=",
+      "requires": {
+        "array-difference": "0.0.1",
+        "isobject": "^0.2.0"
+      }
+    },
+    "on-finished": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
+      "integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
+      "requires": {
+        "ee-first": "1.1.1"
       }
     },
     "once": {
@@ -5755,13 +2222,27 @@
         "wrappy": "1"
       }
     },
-    "optimist": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
-      "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
+    "open": {
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/open/-/open-7.4.2.tgz",
+      "integrity": "sha512-MVHddDVweXZF3awtlAS+6pgKLlm/JgxZ90+/NBurBoQctVOOB/zDdVjcyPzQ+0laDGbsWgrRkflI65sQeOgT9Q==",
       "requires": {
-        "minimist": "~0.0.1",
-        "wordwrap": "~0.0.2"
+        "is-docker": "^2.0.0",
+        "is-wsl": "^2.1.1"
+      }
+    },
+    "optionator": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
+      "integrity": "sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==",
+      "optional": true,
+      "requires": {
+        "deep-is": "~0.1.3",
+        "fast-levenshtein": "~2.0.6",
+        "levn": "~0.3.0",
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2",
+        "word-wrap": "~1.2.3"
       }
     },
     "os-homedir": {
@@ -5783,6 +2264,27 @@
         "os-tmpdir": "^1.0.0"
       }
     },
+    "p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "requires": {
+        "p-try": "^2.0.0"
+      }
+    },
+    "p-locate": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "requires": {
+        "p-limit": "^2.2.0"
+      }
+    },
+    "p-try": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="
+    },
     "parse-filepath": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/parse-filepath/-/parse-filepath-1.0.2.tgz",
@@ -5793,36 +2295,31 @@
         "path-root": "^0.1.1"
       }
     },
-    "parse-json": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
-      "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
-      "requires": {
-        "error-ex": "^1.2.0"
-      }
-    },
     "parse-passwd": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/parse-passwd/-/parse-passwd-1.0.0.tgz",
       "integrity": "sha1-bVuTSkVpk7I9N/QKOC1vFmao5cY="
     },
-    "pascalcase": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
-      "integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ="
+    "parse5": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-1.5.1.tgz",
+      "integrity": "sha1-m387DeMr543CQBsXVzzK8Pb1nZQ=",
+      "optional": true
     },
     "path-exists": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
-      "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
-      "requires": {
-        "pinkie-promise": "^2.0.0"
-      }
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="
     },
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+    },
+    "path-key": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+      "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A="
     },
     "path-parse": {
       "version": "1.0.7",
@@ -5842,66 +2339,96 @@
       "resolved": "https://registry.npmjs.org/path-root-regex/-/path-root-regex-0.1.2.tgz",
       "integrity": "sha1-v8zcjfWxLcUsi0PsONGNcsBLqW0="
     },
-    "path-type": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
-      "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
-      "requires": {
-        "graceful-fs": "^4.1.2",
-        "pify": "^2.0.0",
-        "pinkie-promise": "^2.0.0"
-      }
+    "performance-now": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
+    },
+    "picomatch": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
+      "integrity": "sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw=="
     },
     "pify": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-      "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
+      "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g=="
     },
-    "pinkie": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-      "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA="
-    },
-    "pinkie-promise": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-      "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
-      "requires": {
-        "pinkie": "^2.0.0"
-      }
-    },
-    "posix-character-classes": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
-      "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs="
+    "prelude-ls": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+      "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
+      "optional": true
     },
     "pretty-bytes": {
       "version": "5.6.0",
       "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-5.6.0.tgz",
       "integrity": "sha512-FFw039TmrBqFK8ma/7OL3sDz/VytdtJr044/QUJtH0wK9lb9jLq9tJyIxUwtQJHwar2BqtiA4iCWSwo9JLkzFg=="
     },
-    "q": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/q/-/q-1.5.0.tgz",
-      "integrity": "sha1-3QG6ydBtMObyGa7LglPunr3DCPE="
+    "psl": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
+      "integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ=="
     },
-    "read-pkg": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
-      "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
+    "punycode": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
+    },
+    "q": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
+      "integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc="
+    },
+    "qs": {
+      "version": "6.5.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
+      "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
+    },
+    "range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="
+    },
+    "raw-body": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-1.1.7.tgz",
+      "integrity": "sha1-HQJ8K/oRasxmI7yo8AAWVyqH1CU=",
       "requires": {
-        "load-json-file": "^1.0.0",
-        "normalize-package-data": "^2.3.2",
-        "path-type": "^1.0.0"
+        "bytes": "1",
+        "string_decoder": "0.10"
+      },
+      "dependencies": {
+        "string_decoder": {
+          "version": "0.10.31",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+        }
       }
     },
-    "read-pkg-up": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
-      "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
+    "read-installed": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/read-installed/-/read-installed-4.0.3.tgz",
+      "integrity": "sha1-/5uLZ/GH0eTCm5/rMfayI6zRkGc=",
       "requires": {
-        "find-up": "^1.0.0",
-        "read-pkg": "^1.0.0"
+        "debuglog": "^1.0.1",
+        "graceful-fs": "^4.1.2",
+        "read-package-json": "^2.0.0",
+        "readdir-scoped-modules": "^1.0.0",
+        "semver": "2 || 3 || 4 || 5",
+        "slide": "~1.1.3",
+        "util-extend": "^1.0.1"
+      }
+    },
+    "read-package-json": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/read-package-json/-/read-package-json-2.1.2.tgz",
+      "integrity": "sha512-D1KmuLQr6ZSJS0tW8hf3WGpRlwszJOXZ3E8Yd/DNRaM5d+1wVRZdHlpGBLAuovjr28LbWvjpWkBHMxpRGGjzNA==",
+      "requires": {
+        "glob": "^7.1.1",
+        "json-parse-even-better-errors": "^2.3.0",
+        "normalize-package-data": "^2.0.0",
+        "npm-normalize-package-bin": "^1.0.0"
       }
     },
     "readable-stream": {
@@ -5914,55 +2441,76 @@
         "util-deprecate": "^1.0.1"
       }
     },
+    "readdir-scoped-modules": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/readdir-scoped-modules/-/readdir-scoped-modules-1.1.0.tgz",
+      "integrity": "sha512-asaikDeqAQg7JifRsZn1NJZXo9E+VwlyCfbkZhwyISinqk5zNS6266HS5kah6P0SaQKGF6SkNnZVHUzHFYxYDw==",
+      "requires": {
+        "debuglog": "^1.0.1",
+        "dezalgo": "^1.0.0",
+        "graceful-fs": "^4.1.2",
+        "once": "^1.3.0"
+      }
+    },
+    "readdirp": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "requires": {
+        "picomatch": "^2.2.1"
+      }
+    },
     "rechoir": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
-      "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.7.1.tgz",
+      "integrity": "sha512-/njmZ8s1wVeR6pjTZ+0nCnv8SpZNRMT2D1RLOJQESlYFDBvwpTA4KWJpZ+sBJ4+vhjILRcK7JIFdGCdxEAAitg==",
       "requires": {
-        "resolve": "^1.1.6"
+        "resolve": "^1.9.0"
       }
     },
-    "redent": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
-      "integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
+    "request": {
+      "version": "2.88.2",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
+      "integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
       "requires": {
-        "indent-string": "^2.1.0",
-        "strip-indent": "^1.0.1"
+        "aws-sign2": "~0.7.0",
+        "aws4": "^1.8.0",
+        "caseless": "~0.12.0",
+        "combined-stream": "~1.0.6",
+        "extend": "~3.0.2",
+        "forever-agent": "~0.6.1",
+        "form-data": "~2.3.2",
+        "har-validator": "~5.1.3",
+        "http-signature": "~1.2.0",
+        "is-typedarray": "~1.0.0",
+        "isstream": "~0.1.2",
+        "json-stringify-safe": "~5.0.1",
+        "mime-types": "~2.1.19",
+        "oauth-sign": "~0.9.0",
+        "performance-now": "^2.1.0",
+        "qs": "~6.5.2",
+        "safe-buffer": "^5.1.2",
+        "tough-cookie": "~2.5.0",
+        "tunnel-agent": "^0.6.0",
+        "uuid": "^3.3.2"
       }
     },
-    "regex-not": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
-      "integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
-      "requires": {
-        "extend-shallow": "^3.0.2",
-        "safe-regex": "^1.1.0"
-      }
+    "require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
     },
-    "repeat-element": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.3.tgz",
-      "integrity": "sha512-ahGq0ZnV5m5XtZLMb+vP76kcAM5nkLqk0lpqAuojSKGgQtn4eRi4ZZGm2olo2zKFH+sMsWaqOCW1dqAnOru72g=="
-    },
-    "repeat-string": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
-      "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc="
-    },
-    "repeating": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
-      "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
-      "requires": {
-        "is-finite": "^1.0.0"
-      }
+    "require-main-filename": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg=="
     },
     "resolve": {
-      "version": "1.17.0",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.17.0.tgz",
-      "integrity": "sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==",
+      "version": "1.20.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.20.0.tgz",
+      "integrity": "sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==",
       "requires": {
+        "is-core-module": "^2.2.0",
         "path-parse": "^1.0.6"
       }
     },
@@ -5975,37 +2523,12 @@
         "global-modules": "^1.0.0"
       }
     },
-    "resolve-url": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
-      "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo="
-    },
-    "ret": {
-      "version": "0.1.15",
-      "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
-      "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg=="
-    },
     "rimraf": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
-      "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+      "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
       "requires": {
         "glob": "^7.1.3"
-      },
-      "dependencies": {
-        "glob": {
-          "version": "7.1.6",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
-          "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
-          "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
-          }
-        }
       }
     },
     "safe-buffer": {
@@ -6013,168 +2536,84 @@
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
       "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
     },
-    "safe-regex": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
-      "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
-      "requires": {
-        "ret": "~0.1.10"
-      }
+    "safe-json-parse": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/safe-json-parse/-/safe-json-parse-1.0.1.tgz",
+      "integrity": "sha1-PnZyPjjf3aE8mx0poeB//uSzC1c="
     },
     "safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
+    "sax": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
+      "optional": true
+    },
     "semver": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
-      "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8="
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
     },
-    "set-value": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.1.tgz",
-      "integrity": "sha512-JxHc1weCN68wRY0fhCoXpyK55m/XPHafOmK4UWD7m2CI14GMcFypt4w/0+NV5f/ZMby2F6S2wwA7fgynh9gWSw==",
+    "send": {
+      "version": "0.17.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.17.1.tgz",
+      "integrity": "sha512-BsVKsiGcQMFwT8UxypobUKyv7irCNRHk1T0G680vk88yf6LBByGcZJOTJCrTP2xVN6yI+XjPJcNuE3V4fT9sAg==",
       "requires": {
-        "extend-shallow": "^2.0.1",
-        "is-extendable": "^0.1.1",
-        "is-plain-object": "^2.0.3",
-        "split-string": "^3.0.1"
-      },
-      "dependencies": {
-        "extend-shallow": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-          "requires": {
-            "is-extendable": "^0.1.0"
-          }
-        }
+        "debug": "2.6.9",
+        "depd": "~1.1.2",
+        "destroy": "~1.0.4",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "fresh": "0.5.2",
+        "http-errors": "~1.7.2",
+        "mime": "1.6.0",
+        "ms": "2.1.1",
+        "on-finished": "~2.3.0",
+        "range-parser": "~1.2.1",
+        "statuses": "~1.5.0"
       }
     },
-    "signal-exit": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
-      "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA=="
+    "set-blocking": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
     },
-    "snapdragon": {
-      "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
-      "integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
+    "setprototypeof": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.1.tgz",
+      "integrity": "sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw=="
+    },
+    "shebang-command": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+      "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
       "requires": {
-        "base": "^0.11.1",
-        "debug": "^2.2.0",
-        "define-property": "^0.2.5",
-        "extend-shallow": "^2.0.1",
-        "map-cache": "^0.2.2",
-        "source-map": "^0.5.6",
-        "source-map-resolve": "^0.5.0",
-        "use": "^3.1.0"
-      },
-      "dependencies": {
-        "define-property": {
-          "version": "0.2.5",
-          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
-          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-          "requires": {
-            "is-descriptor": "^0.1.0"
-          }
-        },
-        "extend-shallow": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-          "requires": {
-            "is-extendable": "^0.1.0"
-          }
-        }
+        "shebang-regex": "^1.0.0"
       }
     },
-    "snapdragon-node": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
-      "integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
-      "requires": {
-        "define-property": "^1.0.0",
-        "isobject": "^3.0.0",
-        "snapdragon-util": "^3.0.1"
-      },
-      "dependencies": {
-        "define-property": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
-          "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
-          "requires": {
-            "is-descriptor": "^1.0.0"
-          }
-        },
-        "is-accessor-descriptor": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
-          "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
-          "requires": {
-            "kind-of": "^6.0.0"
-          }
-        },
-        "is-data-descriptor": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
-          "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
-          "requires": {
-            "kind-of": "^6.0.0"
-          }
-        },
-        "is-descriptor": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
-          "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
-          "requires": {
-            "is-accessor-descriptor": "^1.0.0",
-            "is-data-descriptor": "^1.0.0",
-            "kind-of": "^6.0.2"
-          }
-        }
-      }
+    "shebang-regex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+      "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
     },
-    "snapdragon-util": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
-      "integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
-      "requires": {
-        "kind-of": "^3.2.0"
-      },
-      "dependencies": {
-        "kind-of": {
-          "version": "3.2.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-          "requires": {
-            "is-buffer": "^1.1.5"
-          }
-        }
-      }
+    "slick": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/slick/-/slick-1.12.2.tgz",
+      "integrity": "sha1-vQSN23TefRymkV+qSldXCzVQwtc="
+    },
+    "slide": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
+      "integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc="
     },
     "source-map": {
-      "version": "0.5.7",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
-    },
-    "source-map-resolve": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.3.tgz",
-      "integrity": "sha512-Htz+RnsXWk5+P2slx5Jh3Q66vhQj1Cllm0zvnaY98+NFx+Dv2CF/f5O/t8x+KaNdrdIAsruNzoh/KpialbqAnw==",
-      "requires": {
-        "atob": "^2.1.2",
-        "decode-uri-component": "^0.2.0",
-        "resolve-url": "^0.2.1",
-        "source-map-url": "^0.4.0",
-        "urix": "^0.1.0"
-      }
-    },
-    "source-map-url": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
-      "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM="
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
     },
     "spdx-correct": {
       "version": "3.1.1",
@@ -6200,40 +2639,49 @@
       }
     },
     "spdx-license-ids": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.5.tgz",
-      "integrity": "sha512-J+FWzZoynJEXGphVIS+XEh3kFSjZX/1i9gFBaWQcB+/tmpe2qUsSBABpcxqxnAxFdiUFEgAX1bjYGQvIZmoz9Q=="
-    },
-    "split-string": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
-      "integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
-      "requires": {
-        "extend-shallow": "^3.0.0"
-      }
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.10.tgz",
+      "integrity": "sha512-oie3/+gKf7QtpitB0LYLETe+k8SifzsX4KixvpOsbI6S0kRiRQ5MKOio8eMSAKQ17N06+wdEOXRiId+zOxo0hA=="
     },
     "sprintf-js": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.2.tgz",
-      "integrity": "sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug=="
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
     },
-    "static-extend": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
-      "integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
+    "sshpk": {
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
+      "integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
       "requires": {
-        "define-property": "^0.2.5",
-        "object-copy": "^0.1.0"
-      },
-      "dependencies": {
-        "define-property": {
-          "version": "0.2.5",
-          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
-          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-          "requires": {
-            "is-descriptor": "^0.1.0"
-          }
-        }
+        "asn1": "~0.2.3",
+        "assert-plus": "^1.0.0",
+        "bcrypt-pbkdf": "^1.0.0",
+        "dashdash": "^1.12.0",
+        "ecc-jsbn": "~0.1.1",
+        "getpass": "^0.1.1",
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.0.2",
+        "tweetnacl": "~0.14.0"
+      }
+    },
+    "statuses": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
+      "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow="
+    },
+    "string-template": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/string-template/-/string-template-0.2.1.tgz",
+      "integrity": "sha1-QpMuWYo1LQH8IuwzZ9nYTuxsmt0="
+    },
+    "string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "requires": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
       }
     },
     "string_decoder": {
@@ -6244,20 +2692,12 @@
         "safe-buffer": "~5.2.0"
       }
     },
-    "strip-bom": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
-      "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+    "strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
       "requires": {
-        "is-utf8": "^0.2.0"
-      }
-    },
-    "strip-indent": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
-      "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
-      "requires": {
-        "get-stdin": "^4.0.1"
+        "ansi-regex": "^5.0.1"
       }
     },
     "supports-color": {
@@ -6268,56 +2708,97 @@
         "has-flag": "^3.0.0"
       }
     },
-    "tmp": {
-      "version": "0.0.31",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.31.tgz",
-      "integrity": "sha1-jzirlDjhcxXl29izZX6L+yd65Kc=",
-      "requires": {
-        "os-tmpdir": "~1.0.1"
-      }
+    "symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "optional": true
     },
-    "to-object-path": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
-      "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
+    "tiny-lr": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tiny-lr/-/tiny-lr-1.1.1.tgz",
+      "integrity": "sha512-44yhA3tsaRoMOjQQ+5v5mVdqef+kH6Qze9jTpqtVufgYjYt08zyZAwNwwVBj3i1rJMnR52IxOW0LK0vBzgAkuA==",
       "requires": {
-        "kind-of": "^3.0.2"
+        "body": "^5.1.0",
+        "debug": "^3.1.0",
+        "faye-websocket": "~0.10.0",
+        "livereload-js": "^2.3.0",
+        "object-assign": "^4.1.0",
+        "qs": "^6.4.0"
       },
       "dependencies": {
-        "kind-of": {
-          "version": "3.2.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+        "debug": {
+          "version": "3.2.7",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+          "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
           "requires": {
-            "is-buffer": "^1.1.5"
+            "ms": "^2.1.1"
           }
         }
       }
     },
-    "to-regex": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz",
-      "integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
+    "tmp": {
+      "version": "0.0.28",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.28.tgz",
+      "integrity": "sha1-Fyc1t/YU6nrzlmT6hM8N5OUV0SA=",
       "requires": {
-        "define-property": "^2.0.2",
-        "extend-shallow": "^3.0.2",
-        "regex-not": "^1.0.2",
-        "safe-regex": "^1.1.0"
+        "os-tmpdir": "~1.0.1"
       }
     },
     "to-regex-range": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
-      "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
       "requires": {
-        "is-number": "^3.0.0",
-        "repeat-string": "^1.6.1"
+        "is-number": "^7.0.0"
       }
     },
-    "trim-newlines": {
+    "toidentifier": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
-      "integrity": "sha1-WIeWa7WCpFA6QetST301ARgVphM="
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",
+      "integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw=="
+    },
+    "tough-cookie": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
+      "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
+      "requires": {
+        "psl": "^1.1.28",
+        "punycode": "^2.1.1"
+      }
+    },
+    "tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=",
+      "optional": true
+    },
+    "try-resolve": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/try-resolve/-/try-resolve-1.0.1.tgz",
+      "integrity": "sha1-z95vq9ctY+V5fPqrhzq76OcA6RI="
+    },
+    "tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+      "requires": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "tweetnacl": {
+      "version": "0.14.5",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
+    },
+    "type-check": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
+      "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+      "optional": true,
+      "requires": {
+        "prelude-ls": "~1.1.2"
+      }
     },
     "unc-path-regex": {
       "version": "0.1.2",
@@ -6333,88 +2814,51 @@
         "util-deprecate": "^1.0.2"
       }
     },
-    "union-value": {
+    "unxhr": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.1.tgz",
-      "integrity": "sha512-tJfXmxMeWYnczCVs7XAEvIV7ieppALdyepWMkHkwciRpZraG/xwT+s2JN8+pr1+8jCRf80FFzvr+MpQeeoF4Xg==",
+      "resolved": "https://registry.npmjs.org/unxhr/-/unxhr-1.0.1.tgz",
+      "integrity": "sha512-MAhukhVHyaLGDjyDYhy8gVjWJyhTECCdNsLwlMoGFoNJ3o79fpQhtQuzmAE4IxCMDwraF4cW8ZjpAV0m9CRQbg=="
+    },
+    "uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
       "requires": {
-        "arr-union": "^3.1.0",
-        "get-value": "^2.0.6",
-        "is-extendable": "^0.1.1",
-        "set-value": "^2.0.1"
+        "punycode": "^2.1.0"
       }
     },
-    "universalify": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="
-    },
-    "unset-value": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz",
-      "integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
-      "requires": {
-        "has-value": "^0.3.1",
-        "isobject": "^3.0.0"
-      },
-      "dependencies": {
-        "has-value": {
-          "version": "0.3.1",
-          "resolved": "https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz",
-          "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
-          "requires": {
-            "get-value": "^2.0.3",
-            "has-values": "^0.1.4",
-            "isobject": "^2.0.0"
-          },
-          "dependencies": {
-            "isobject": {
-              "version": "2.1.0",
-              "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
-              "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
-              "requires": {
-                "isarray": "1.0.0"
-              }
-            }
-          }
-        },
-        "has-values": {
-          "version": "0.1.4",
-          "resolved": "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz",
-          "integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E="
-        }
-      }
-    },
-    "urix": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
-      "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI="
-    },
-    "use": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
-      "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ=="
-    },
-    "user-home": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/user-home/-/user-home-2.0.0.tgz",
-      "integrity": "sha1-nHC/2Babwdy/SGBODwS4tJzenp8=",
-      "requires": {
-        "os-homedir": "^1.0.0"
-      }
+    "urijs": {
+      "version": "1.19.7",
+      "resolved": "https://registry.npmjs.org/urijs/-/urijs-1.19.7.tgz",
+      "integrity": "sha512-Id+IKjdU0Hx+7Zx717jwLPsPeUqz7rAtuVBRLLs+qn+J2nf9NGITWVCxcijgYxBqe83C7sqsQPs6H1pyz3x9gA=="
     },
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
+    "util-extend": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/util-extend/-/util-extend-1.0.3.tgz",
+      "integrity": "sha1-p8IW0mdUUWljeztu3GypEZ4v+T8="
+    },
+    "uuid": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
+    },
     "v8flags": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/v8flags/-/v8flags-3.1.3.tgz",
-      "integrity": "sha512-amh9CCg3ZxkzQ48Mhcb8iX7xpAfYJgePHxWMQCBWECpOSqJUXgY26ncA61UTV0BkPqfhcy6mzwCIoP4ygxpW8w==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/v8flags/-/v8flags-3.2.0.tgz",
+      "integrity": "sha512-mH8etigqMfiGWdeXpaaqGfs6BndypxusHHcv2qSHyZkGEznCd/qAXCWWRzeowtL54147cktFOC4P5y+kl8d8Jg==",
       "requires": {
         "homedir-polyfill": "^1.0.1"
       }
+    },
+    "valid-data-url": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/valid-data-url/-/valid-data-url-2.0.0.tgz",
+      "integrity": "sha512-dyCZnv3aCey7yfTgIqdZanKl7xWAEEKCbgmR7SKqyK6QT/Z07ROactrgD1eA37C69ODRj7rNOjzKWVPh0EUjBA=="
     },
     "valid-url": {
       "version": "1.0.9",
@@ -6430,23 +2874,234 @@
         "spdx-expression-parse": "^3.0.0"
       }
     },
+    "verror": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+      "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+      "requires": {
+        "assert-plus": "^1.0.0",
+        "core-util-is": "1.0.2",
+        "extsprintf": "^1.2.0"
+      },
+      "dependencies": {
+        "core-util-is": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+          "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+        }
+      }
+    },
+    "web-resource-inliner": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/web-resource-inliner/-/web-resource-inliner-4.3.4.tgz",
+      "integrity": "sha512-agVAgRhOOi4GVlvKK34oM23tDgH8390HfLnZY2HZl8OFBwKNvUJkH7t89AT2iluQP8w9VHAAKX6Z8EN7/9tqKA==",
+      "requires": {
+        "async": "^3.1.0",
+        "chalk": "^2.4.2",
+        "datauri": "^2.0.0",
+        "htmlparser2": "^4.0.0",
+        "lodash.unescape": "^4.0.1",
+        "request": "^2.88.0",
+        "safer-buffer": "^2.1.2",
+        "valid-data-url": "^2.0.0",
+        "xtend": "^4.0.2"
+      },
+      "dependencies": {
+        "dom-serializer": {
+          "version": "1.3.2",
+          "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-1.3.2.tgz",
+          "integrity": "sha512-5c54Bk5Dw4qAxNOI1pFEizPSjVsx5+bpJKmL2kPn8JhBUq2q09tTCa3mjijun2NfK78NMouDYNMBkOrPZiS+ig==",
+          "requires": {
+            "domelementtype": "^2.0.1",
+            "domhandler": "^4.2.0",
+            "entities": "^2.0.0"
+          },
+          "dependencies": {
+            "domhandler": {
+              "version": "4.2.2",
+              "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.2.2.tgz",
+              "integrity": "sha512-PzE9aBMsdZO8TK4BnuJwH0QT41wgMbRzuZrHUcpYncEjmQazq8QEaBWgLG7ZyC/DAZKEgglpIA6j4Qn/HmxS3w==",
+              "requires": {
+                "domelementtype": "^2.2.0"
+              }
+            }
+          }
+        },
+        "domelementtype": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.2.0.tgz",
+          "integrity": "sha512-DtBMo82pv1dFtUmHyr48beiuq792Sxohr+8Hm9zoxklYPfa6n0Z3Byjj2IV7bmr2IyqClnqEQhfgHJJ5QF0R5A=="
+        },
+        "domhandler": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-3.3.0.tgz",
+          "integrity": "sha512-J1C5rIANUbuYK+FuFL98650rihynUOEzRLxW+90bKZRWB6A1X1Tf82GxR1qAWLyfNPRvjqfip3Q5tdYlmAa9lA==",
+          "requires": {
+            "domelementtype": "^2.0.1"
+          }
+        },
+        "domutils": {
+          "version": "2.8.0",
+          "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.8.0.tgz",
+          "integrity": "sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A==",
+          "requires": {
+            "dom-serializer": "^1.0.1",
+            "domelementtype": "^2.2.0",
+            "domhandler": "^4.2.0"
+          },
+          "dependencies": {
+            "domhandler": {
+              "version": "4.2.2",
+              "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.2.2.tgz",
+              "integrity": "sha512-PzE9aBMsdZO8TK4BnuJwH0QT41wgMbRzuZrHUcpYncEjmQazq8QEaBWgLG7ZyC/DAZKEgglpIA6j4Qn/HmxS3w==",
+              "requires": {
+                "domelementtype": "^2.2.0"
+              }
+            }
+          }
+        },
+        "entities": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
+          "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A=="
+        },
+        "htmlparser2": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-4.1.0.tgz",
+          "integrity": "sha512-4zDq1a1zhE4gQso/c5LP1OtrhYTncXNSpvJYtWJBtXAETPlMfi3IFNjGuQbYLuVY4ZR0QMqRVvo4Pdy9KLyP8Q==",
+          "requires": {
+            "domelementtype": "^2.0.1",
+            "domhandler": "^3.0.0",
+            "domutils": "^2.0.0",
+            "entities": "^2.0.0"
+          }
+        }
+      }
+    },
+    "webidl-conversions": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-2.0.1.tgz",
+      "integrity": "sha1-O/glj30xjHRDw28uFpQCoaZwNQY=",
+      "optional": true
+    },
+    "websocket-driver": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.4.tgz",
+      "integrity": "sha512-b17KeDIQVjvb0ssuSDF2cYXSg2iztliJ4B9WdsuB6J952qCPKmnVq4DyW5motImXHDC1cBT/1UezrJVsKw5zjg==",
+      "requires": {
+        "http-parser-js": ">=0.5.1",
+        "safe-buffer": ">=5.1.0",
+        "websocket-extensions": ">=0.1.1"
+      }
+    },
+    "websocket-extensions": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.4.tgz",
+      "integrity": "sha512-OqedPIGOfsDlo31UNwYbCFMSaO9m9G/0faIHj5/dZFDMFqPTcx6UwqyOy3COEaEOg/9VsGIpdqn62W5KhoKSpg=="
+    },
+    "whatwg-url-compat": {
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/whatwg-url-compat/-/whatwg-url-compat-0.6.5.tgz",
+      "integrity": "sha1-AImBEa9om7CXVBzVpFymyHmERb8=",
+      "optional": true,
+      "requires": {
+        "tr46": "~0.0.1"
+      }
+    },
     "which": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
-      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
       "requires": {
         "isexe": "^2.0.0"
       }
     },
-    "wordwrap": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
-      "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc="
+    "which-module": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+      "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
+    },
+    "word-wrap": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
+      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
+      "optional": true
+    },
+    "wrap-ansi": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+      "requires": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      }
     },
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+    },
+    "write": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/write/-/write-1.0.3.tgz",
+      "integrity": "sha512-/lg70HAjtkUgWPVZhZcm+T4hkL8Zbtp1nFNOn3lRrxnlv50SRBv7cR7RqR+GMsd3hUXy9hWBo4CHTbFTcOYwig==",
+      "requires": {
+        "mkdirp": "^0.5.1"
+      },
+      "dependencies": {
+        "mkdirp": {
+          "version": "0.5.5",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+          "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
+          "requires": {
+            "minimist": "^1.2.5"
+          }
+        }
+      }
+    },
+    "xml-name-validator": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-2.0.1.tgz",
+      "integrity": "sha1-TYuPHszTQZqjYgYb7O9RXh5VljU=",
+      "optional": true
+    },
+    "xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="
+    },
+    "y18n": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+      "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ=="
+    },
+    "yargs": {
+      "version": "15.3.1",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.3.1.tgz",
+      "integrity": "sha512-92O1HWEjw27sBfgmXiixJWT5hRBp2eobqXicLtPBIDBhYB+1HpwZlXmbW2luivBJHBzki+7VyCLRtAkScbTBQA==",
+      "requires": {
+        "cliui": "^6.0.0",
+        "decamelize": "^1.2.0",
+        "find-up": "^4.1.0",
+        "get-caller-file": "^2.0.1",
+        "require-directory": "^2.1.1",
+        "require-main-filename": "^2.0.0",
+        "set-blocking": "^2.0.0",
+        "string-width": "^4.2.0",
+        "which-module": "^2.0.0",
+        "y18n": "^4.0.0",
+        "yargs-parser": "^18.1.1"
+      }
+    },
+    "yargs-parser": {
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+      "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+      "requires": {
+        "camelcase": "^5.0.0",
+        "decamelize": "^1.2.0"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -5,22 +5,21 @@
   "description": "Welcome to GoCD - an open-source Continuous Integration and Continuous Delivery server. Please take a minute to understand [the basic concepts in Go](introduction/concepts_in_go.md) before you go any further.",
   "main": "index.js",
   "scripts": {
-    "init-gitbook": "gitbook install",
-    "server": "gitbook serve",
-    "build": "gitbook build .",
+    "server": "honkit serve",
+    "build": "honkit build .",
     "minify": "grunt"
   },
   "author": "ThoughtWorks, Inc.",
   "license": "Apache-2.0",
   "dependencies": {
-    "gitbook-cli": "^2.3.2",
     "gitbook-plugin-anchors": "^0.7.1",
     "gitbook-plugin-collapsible-menu": "^1.0.3",
     "gitbook-plugin-ga": "^1.0.1",
     "gitbook-plugin-highlight": "^2.0.3",
     "gitbook-plugin-redirect": "0.0.7",
-    "grunt": "^1.1.0",
-    "grunt-cli": "^1.3.2",
-    "grunt-contrib-cssmin": "^4.0.0"
+    "grunt": "^1.4.1",
+    "grunt-cli": "^1.4.3",
+    "grunt-contrib-cssmin": "^4.0.0",
+    "honkit": "^3.6.23"
   }
 }

--- a/rakelib/build.rake
+++ b/rakelib/build.rake
@@ -1,7 +1,6 @@
 desc "build the documentation"
 task :build do
   sh('npm install')
-  sh('npm run init-gitbook')
   sh('npm run build')
   sh('npm run minify')
 end


### PR DESCRIPTION
https://github.com/honkit/honkit - Still Apache 2, same as legacy Gitbook.

The legacy Gitbook CLI seems to be broken on MacOS due to some `graceful-fs` issues an an ancient embedded npm version.

Honkit is compatible with the original Gitbook 3 and at least maintained, and it doesn't seem work switching this simple developer documentation to Hugo right now. Seems to work just fine on Honkit.